### PR TITLE
feat: Add INDEX.md manifest to context-path archives (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The **context-path** feature redirects these artifacts to a sibling directory ou
 
 When set:
 - **`archive-work`** archives scratchpads and session logs to `{context-path}/{branch}/archive/` instead of `docs/dev/cc-archive/`
+- **`archive-work`** also maintains `{context-path}/INDEX.md` — a chronological table of all archived work across branches (newest-first)
 - **`stash-artifact`** saves ad hoc scripts and notes to `{context-path}/{branch}/scripts/` or `{context-path}/{branch}/notes/`
 
 Note: The PreCompact hook always writes `SESSION_LOG_{N}.md` to the project root (alongside the scratchpad). Session logs are moved to the context directory by `archive-work` at archive time.

--- a/docs/CONTEXT_PATH.md
+++ b/docs/CONTEXT_PATH.md
@@ -45,6 +45,7 @@ The context directory uses a flat-on-main, directory-per-branch layout:
 
 ```
 myproject-ctx/
+├── INDEX.md
 ├── main/
 │   ├── notes/
 │   └── scripts/
@@ -88,7 +89,34 @@ The archive-work skill gains context-path awareness:
 6. Commit in code repo only removes the scratchpad (clean)
 7. Context directory changes are left for the operator to commit/push separately
 
-### 5. New Skill (stash-artifact)
+### 5. INDEX.md Manifest
+
+The `archive-work` skill maintains an `INDEX.md` file at the root of the context directory. Each time work is archived, a row is added to a chronological table:
+
+```
+{context-path}/INDEX.md
+```
+
+**Format:**
+
+```markdown
+# Archive Index
+
+| Archived | Branch | Issue | Status |
+|----------|--------|-------|--------|
+| 2026-02-25 | 44-refactor-api | [#44](url) Refactor API | Merged |
+| 2026-02-20 | 43-fix-login-bug | [#43](url) Fix login bug | Merged |
+| 2026-02-13 | 42-add-authentication | [#42](url) Add authentication | Merged |
+```
+
+- Rows are newest-first (most recent archive at the top)
+- Created automatically on first archive if it doesn't exist
+- `Status` matches the archive README: `Merged`, `Completed`, or `Abandoned`
+- Renders correctly in both Obsidian and GitHub markdown
+
+The `INDEX.md` file is outside the code repo and not auto-committed. Commit it alongside other context directory changes when desired.
+
+### 6. New Skill (stash-artifact)
 
 A lightweight skill for saving ad hoc scripts and notes to the context directory:
 

--- a/docs/SESSION-ARCHIVING.md
+++ b/docs/SESSION-ARCHIVING.md
@@ -74,11 +74,13 @@ When you use the `archive-work` skill after completing work, session logs are co
 
 **With context-path configured:**
 ```
-{context-path}/{branch}/archive/
-├── SCRATCHPAD_{issue_number}.md
-├── SESSION_LOG_1.md          # Converted from JSONL
-├── SESSION_LOG_2.md
-└── README.md
+{context-path}/
+├── INDEX.md                          # Chronological archive manifest
+└── {branch}/archive/
+    ├── SCRATCHPAD_{issue_number}.md
+    ├── SESSION_LOG_1.md              # Converted from JSONL
+    ├── SESSION_LOG_2.md
+    └── README.md
 ```
 
 **Without context-path (in-repo):**

--- a/skills/archive-work/SKILL.md
+++ b/skills/archive-work/SKILL.md
@@ -285,7 +285,48 @@ Context directory changes:
 
 2. **Write README.md** to archive directory
 
-3. **Commit in Code Repo:**
+3. **Update INDEX.md** (context mode only)
+
+   **Skip this step entirely if `ARCHIVE_MODE=in-repo`.**
+
+   When `ARCHIVE_MODE=context`, maintain a chronological manifest at the context-path root:
+
+   ```
+   INDEX_FILE="{context-path}/INDEX.md"
+   ```
+
+   **Algorithm:**
+
+   1. Read `INDEX_FILE` with the Read tool (if it exists)
+   2. If the file does not exist, initialize it with this header:
+      ```markdown
+      # Archive Index
+
+      | Archived | Branch | Issue | Status |
+      |----------|--------|-------|--------|
+      ```
+   3. Build a new row from the archive metadata (already available from Phase 2/4):
+      ```
+      | {YYYY-MM-DD} | {branch} | [#{issue_number}]({issue_github_url}) {issue_title} | {status} |
+      ```
+      - `{YYYY-MM-DD}`: today's date
+      - `{branch}`: the branch being archived (from `git branch --show-current`)
+      - `{issue_number}`, `{issue_title}`, `{issue_github_url}`: from the scratchpad
+      - `{status}`: the same value used in the archive README (Merged, Completed, or Abandoned)
+   4. Insert the new row **immediately after** the separator line (`|----------|--------|-------|--------|`) so that newest entries appear first
+   5. Write the full updated content back with the Write tool
+
+   **Example result after two archives:**
+   ```markdown
+   # Archive Index
+
+   | Archived | Branch | Issue | Status |
+   |----------|--------|-------|--------|
+   | 2026-02-25 | 44-refactor-api | [#44](https://github.com/owner/repo/issues/44) Refactor API | Merged |
+   | 2026-02-20 | 43-fix-login-bug | [#43](https://github.com/owner/repo/issues/43) Fix login bug | Merged |
+   ```
+
+4. **Commit in Code Repo:**
    If user opted to commit:
 
    **Context mode:**
@@ -326,6 +367,10 @@ Files archived (to context directory):
    - SCRATCHPAD_{issue_number}.md
    - SESSION_LOG_*.md (if any existed)
    - README.md (summary generated)
+
+INDEX.md updated:
+   - {context-path}/INDEX.md
+   - Added row: {date} | {branch} | #{issue_number} | {status}
 
 Code repo cleanup:
    - Removed SCRATCHPAD_{issue_number}.md (git rm)
@@ -478,10 +523,11 @@ No PR found for this work.
 
 ---
 
-**Version:** 2.1.0
+**Version:** 2.2.0
 **Last Updated:** 2026-02-25
 **Maintained By:** Escapement
 **Changelog:**
+- v2.2.0: Maintain INDEX.md manifest at context-path root on archive (#25)
 - v2.1.0: Added JSONL→markdown conversion (Phase 3.5) for simplified PreCompact hook (#27)
 - v2.0.0: Added context-path support for external archive directories
 - v1.3.0: Added parallel execution for artifact detection


### PR DESCRIPTION
## Summary
- `archive-work` skill now maintains a chronological `INDEX.md` manifest at the context-path root
- Each archive appends a newest-first row with date, branch, issue link, and status
- Only applies in context mode (no effect on in-repo archiving)

## Issue Resolution
Closes #25

## Key Changes
- **`skills/archive-work/SKILL.md`**: Added Phase 6 Step 3 — INDEX.md creation/update algorithm with context-mode guard, updated Phase 7 report output, bumped to v2.2.0
- **`docs/CONTEXT_PATH.md`**: Added INDEX.md to directory diagram, new section documenting the manifest format and behavior
- **`docs/SESSION-ARCHIVING.md`**: Updated context-path archive tree to show INDEX.md at root
- **`README.md`**: Added INDEX.md bullet to context-path feature description

## Testing
Tested by reviewing skill instructions for correctness and consistency across all documentation files. Runtime validation will occur on next `archive-work` invocation in a context-path project.

## Checklist
- [x] Code follows project conventions
- [x] Changes are atomic and reviewable
- [x] Documentation updated
- [x] All acceptance criteria from issue addressed