### PR TITLE
feat: Migrate manifest database from PGlite to better-sqlite3 (#52)

### DIFF
--- a/manifest/init.ts
+++ b/manifest/init.ts
@@ -1,60 +1,96 @@
-import { PGlite } from "@electric-sql/pglite";
-import { readFileSync } from "node:fs";
+import Database from "better-sqlite3";
+import type { Database as DatabaseType } from "better-sqlite3";
+import { readFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { mkdirSync } from "node:fs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCHEMA_PATH = resolve(__dirname, "schema.sql");
 
 /**
- * Get or create a PGlite database instance at the given data directory.
- * If no dataDir is provided, defaults to {context-path}/manifest/pgdata/
- * where context-path is ../escapement-ctx relative to the repo root.
+ * Parse context-path from the project's CLAUDE.md.
+ * Walks up from the manifest directory to find CLAUDE.md,
+ * then extracts the context-path setting.
  */
-export async function getDb(
-  dataDir?: string
-): Promise<PGlite> {
-  const resolvedDir =
-    dataDir ?? resolve(__dirname, "..", "..", "escapement-ctx", "manifest", "pgdata");
-  const db = await PGlite.create(resolvedDir);
+function resolveContextPath(): string | null {
+  // Look for CLAUDE.md in the repo root (parent of manifest/)
+  const repoRoot = resolve(__dirname, "..");
+  const claudeMd = resolve(repoRoot, "CLAUDE.md");
+  if (!existsSync(claudeMd)) return null;
+
+  const content = readFileSync(claudeMd, "utf-8");
+  // Match: - **context-path**: <value>
+  const match = content.match(/\*\*context-path\*\*:\s*(.+)/);
+  if (!match) return null;
+
+  const raw = match[1].trim();
+  // Resolve relative to repo root
+  return resolve(repoRoot, raw);
+}
+
+/**
+ * Get or create a SQLite database instance at the given path.
+ * If no dataDir is provided, derives the path from CLAUDE.md context-path,
+ * falling back to {repo-root}/../escapement-ctx/manifest/manifest.db.
+ */
+export function getDb(dataDir?: string): DatabaseType {
+  let dbPath: string;
+  if (dataDir) {
+    dbPath = resolve(dataDir, "manifest.db");
+  } else {
+    const contextPath = resolveContextPath();
+    const base = contextPath ?? resolve(__dirname, "..", "..", "escapement-ctx");
+    dbPath = resolve(base, "manifest", "manifest.db");
+  }
+
+  // Ensure parent directory exists
+  const parentDir = dirname(dbPath);
+  if (!existsSync(parentDir)) {
+    mkdirSync(parentDir, { recursive: true });
+  }
+
+  const db = new Database(dbPath);
+  // Enable WAL mode for better concurrent read performance
+  db.pragma("journal_mode = WAL");
+  // Enable foreign key enforcement (off by default in SQLite)
+  db.pragma("foreign_keys = ON");
   return db;
 }
 
 /**
- * Apply the V2 schema to a PGlite instance.
+ * Apply the V2 schema to a SQLite instance.
  * Safe to call on a fresh database. Will error if tables already exist
  * (use ensureSchema for idempotent setup).
  */
-export async function applySchema(db: PGlite): Promise<void> {
+export function applySchema(db: DatabaseType): void {
   const sql = readFileSync(SCHEMA_PATH, "utf-8");
-  await db.exec(sql);
+  db.exec(sql);
 }
 
 /**
  * Idempotent schema setup: only applies if work_items table doesn't exist.
  */
-export async function ensureSchema(db: PGlite): Promise<boolean> {
-  const result = await db.query<{ exists: boolean }>(`
-    SELECT EXISTS (
-      SELECT 1 FROM information_schema.tables
-      WHERE table_name = 'work_items'
-    ) AS exists
-  `);
-  if (result.rows[0].exists) {
+export function ensureSchema(db: DatabaseType): boolean {
+  const row = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='work_items'"
+    )
+    .get() as { name: string } | undefined;
+
+  if (row) {
     return false;
   }
-  await applySchema(db);
+  applySchema(db);
   return true;
 }
 
 /**
- * Initialize the manifest database: create/open the PGlite instance
+ * Initialize the manifest database: create/open the SQLite instance
  * and ensure the schema is applied.
  */
-export async function initManifest(
-  dataDir?: string
-): Promise<PGlite> {
-  const db = await getDb(dataDir);
-  await ensureSchema(db);
+export function initManifest(dataDir?: string): DatabaseType {
+  const db = getDb(dataDir);
+  ensureSchema(db);
   return db;
 }

--- a/manifest/manifest-cli.ts
+++ b/manifest/manifest-cli.ts
@@ -3,14 +3,14 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { initManifest } from "./init.ts";
 import { buildDispatchPlan, formatPlan } from "./plan.ts";
-import type { PGlite } from "@electric-sql/pglite";
+import type { Database } from "better-sqlite3";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function usage(): never {
-  console.log(`Usage: manifest <command> [args]
+  console.log(`Usage: manifest [--data-dir <path>] <command> [args]
 
 Commands:
   seed <file.sql>   Load a SQL seed file into the manifest database
@@ -27,7 +27,10 @@ Check subcommands:
   check new-issues         List manifest issue_numbers for diffing against GitHub
   plan              Generate dispatch plan with parallel groups and overlaps
   query <sql>       Execute inline SQL and print results
-  in-progress <id> <branch>  Mark a work item as in_progress and record its branch`);
+  in-progress <id> <branch>  Mark a work item as in_progress and record its branch
+
+Options:
+  --data-dir <path>  Override the manifest data directory`);
   process.exit(1);
 }
 
@@ -40,9 +43,15 @@ function pct(done: number, total: number): string {
   return `${Math.round((done / total) * 100).toString().padStart(3)}%`;
 }
 
+function parseJsonArray(v: unknown): string[] {
+  if (typeof v === "string") return JSON.parse(v);
+  if (Array.isArray(v)) return v;
+  return [];
+}
+
 // ── Commands ─────────────────────────────────────────────────────────
 
-async function cmdSeed(db: PGlite, args: string[]): Promise<void> {
+function cmdSeed(db: Database, args: string[]): void {
   const filePath = args[0];
   if (!filePath) {
     console.error("Error: seed requires a SQL file path.\n  manifest seed <file.sql>");
@@ -52,36 +61,26 @@ async function cmdSeed(db: PGlite, args: string[]): Promise<void> {
   let sql: string;
   try {
     sql = readFileSync(resolved, "utf-8");
-  } catch (err) {
+  } catch {
     console.error(`Error: cannot read file: ${resolved}`);
     process.exit(1);
   }
-  await db.exec(sql);
+  db.exec(sql);
   // Report what was loaded
-  const items = await db.query<{ count: string }>(
-    "SELECT count(*)::text AS count FROM work_items"
-  );
-  const edges = await db.query<{ count: string }>(
-    "SELECT count(*)::text AS count FROM edges"
-  );
+  const items = db.prepare("SELECT count(*) AS count FROM work_items").get() as { count: number };
+  const edges = db.prepare("SELECT count(*) AS count FROM edges").get() as { count: number };
   console.log(
-    `Seed applied.\n  work_items: ${items.rows[0].count}\n  edges:      ${edges.rows[0].count}`
+    `Seed applied.\n  work_items: ${items.count}\n  edges:      ${edges.count}`
   );
 }
 
-async function cmdFrontier(db: PGlite): Promise<void> {
-  const result = await db.query<{
-    id: string;
-    name: string;
-    kind: string;
-    repo: string | null;
-    scope_hint: string | null;
-  }>(`
+function cmdFrontier(db: Database): void {
+  const rows = db.prepare(`
     SELECT w.id, w.name, w.kind, w.repo, w.scope_hint
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND NOT EXISTS (
         SELECT 1
         FROM edges e
@@ -91,68 +90,63 @@ async function cmdFrontier(db: PGlite): Promise<void> {
           AND dep.state != 'done'
       )
     ORDER BY w.id
-  `);
+  `).all() as { id: string; name: string; kind: string; repo: string | null; scope_hint: string | null }[];
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("No dispatchable work items.");
     return;
   }
 
-  console.log(`Frontier: ${result.rows.length} dispatchable item(s)\n`);
+  console.log(`Frontier: ${rows.length} dispatchable item(s)\n`);
   console.log(
     `  ${pad("ID", 20)} ${pad("KIND", 12)} ${pad("REPO", 24)} NAME`
   );
   console.log(`  ${"─".repeat(20)} ${"─".repeat(12)} ${"─".repeat(24)} ${"─".repeat(30)}`);
-  for (const row of result.rows) {
+  for (const row of rows) {
     console.log(
       `  ${pad(row.id, 20)} ${pad(row.kind, 12)} ${pad(row.repo ?? "-", 24)} ${row.name}`
     );
   }
 }
 
-async function cmdDone(db: PGlite, args: string[]): Promise<void> {
+function cmdDone(db: Database, args: string[]): void {
   const id = args[0];
   if (!id) {
     console.error("Error: done requires a work item id.\n  manifest done <id>");
     process.exit(1);
   }
 
-  // Check item exists
-  const existing = await db.query<{ id: string; state: string }>(
-    "SELECT id, state FROM work_items WHERE id = $1",
-    [id]
-  );
-  if (existing.rows.length === 0) {
+  const existing = db.prepare(
+    "SELECT id, state FROM work_items WHERE id = ?"
+  ).get(id) as { id: string; state: string } | undefined;
+
+  if (!existing) {
     console.error(`Error: work item '${id}' not found.`);
     process.exit(1);
   }
-  if (existing.rows[0].state === "done") {
+  if (existing.state === "done") {
     console.log(`Work item '${id}' is already done.`);
     return;
   }
 
-  await db.query(
-    "UPDATE work_items SET state = 'done', updated_at = now() WHERE id = $1",
-    [id]
-  );
+  db.prepare(
+    "UPDATE work_items SET state = 'done', updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
+  ).run(id);
   console.log(`Marked '${id}' as done.\n`);
 
-  // Show updated frontier
-  await cmdFrontier(db);
+  cmdFrontier(db);
 }
 
-async function cmdStatus(db: PGlite): Promise<void> {
-  // Summary counts across all work items
-  const summary = await db.query<{
-    state: string;
-    count: string;
-  }>("SELECT state, count(*)::text AS count FROM work_items GROUP BY state ORDER BY state");
+function cmdStatus(db: Database): void {
+  const summary = db.prepare(
+    "SELECT state, count(*) AS count FROM work_items GROUP BY state ORDER BY state"
+  ).all() as { state: string; count: number }[];
 
   let total = 0;
   const byState: Record<string, number> = {};
-  for (const row of summary.rows) {
-    byState[row.state] = parseInt(row.count, 10);
-    total += byState[row.state];
+  for (const row of summary) {
+    byState[row.state] = row.count;
+    total += row.count;
   }
 
   console.log("Overall Status\n");
@@ -163,12 +157,7 @@ async function cmdStatus(db: PGlite): Promise<void> {
     }
   }
 
-  // Hierarchical rollup
-  const rollup = await db.query<{
-    name: string;
-    total_items: string;
-    done_items: string;
-  }>(`
+  const rollup = db.prepare(`
     WITH RECURSIVE tree AS (
       SELECT
         parent.id AS root_id,
@@ -189,18 +178,16 @@ async function cmdStatus(db: PGlite): Promise<void> {
     )
     SELECT
       root.name,
-      COUNT(*) FILTER (WHERE leaf.kind IN ('issue', 'capability'))::text AS total_items,
-      COUNT(*) FILTER (
-        WHERE leaf.kind IN ('issue', 'capability') AND leaf.state = 'done'
-      )::text AS done_items
+      COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') THEN 1 END) AS total_items,
+      COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') AND leaf.state = 'done' THEN 1 END) AS done_items
     FROM tree
     JOIN work_items root ON root.id = tree.root_id
     JOIN work_items leaf ON leaf.id = tree.child_id
     GROUP BY root.id, root.name
     ORDER BY root.name
-  `);
+  `).all() as { name: string; total_items: number; done_items: number }[];
 
-  if (rollup.rows.length > 0) {
+  if (rollup.length > 0) {
     console.log(`\nPhase / Track Rollup\n`);
     console.log(
       `  ${pad("NAME", 44)} ${pad("DONE", 6)} ${pad("TOTAL", 6)} PROGRESS`
@@ -208,11 +195,9 @@ async function cmdStatus(db: PGlite): Promise<void> {
     console.log(
       `  ${"─".repeat(44)} ${"─".repeat(6)} ${"─".repeat(6)} ${"─".repeat(8)}`
     );
-    for (const row of rollup.rows) {
-      const done = parseInt(row.done_items, 10);
-      const tot = parseInt(row.total_items, 10);
+    for (const row of rollup) {
       console.log(
-        `  ${pad(row.name, 44)} ${pad(String(done), 6)} ${pad(String(tot), 6)} ${pct(done, tot)}`
+        `  ${pad(row.name, 44)} ${pad(String(row.done_items), 6)} ${pad(String(row.total_items), 6)} ${pct(row.done_items, row.total_items)}`
       );
     }
   }
@@ -220,103 +205,108 @@ async function cmdStatus(db: PGlite): Promise<void> {
 
 // ── Check subcommands ───────────────────────────────────────────────
 
-async function cmdCheckSuperseded(db: PGlite): Promise<void> {
+function cmdCheckSuperseded(db: Database): void {
   const sqlPath = resolve(__dirname, "queries", "superseded.sql");
   const sql = readFileSync(sqlPath, "utf-8");
-  const result = await db.query<{
+  const rows = db.prepare(sql).all() as {
     older_id: string;
     older_name: string;
     older_scope: string | null;
     newer_id: string;
     newer_name: string;
     newer_scope: string | null;
-    shared_files: string[];
-  }>(sql);
+    shared_files: string;
+  }[];
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("No superseded in_progress items detected.");
     return;
   }
 
-  console.log(`Supersession Check: ${result.rows.length} potential supersession(s)\n`);
+  console.log(`Supersession Check: ${rows.length} potential supersession(s)\n`);
   console.log(
     `  ${pad("OLDER ITEM", 20)} ${pad("NEWER ITEM", 20)} SHARED FILES`
   );
   console.log(
     `  ${"─".repeat(20)} ${"─".repeat(20)} ${"─".repeat(40)}`
   );
-  for (const row of result.rows) {
-    const files = row.shared_files.length > 0 ? row.shared_files.join(", ") : "(scope match)";
-    console.log(`  ${pad(row.older_id, 20)} ${pad(row.newer_id, 20)} ${files}`);
+  for (const row of rows) {
+    const files = parseJsonArray(row.shared_files);
+    const display = files.length > 0 ? files.join(", ") : "(scope match)";
+    console.log(`  ${pad(row.older_id, 20)} ${pad(row.newer_id, 20)} ${display}`);
     console.log(`    ${row.older_name}`);
     console.log(`    -> ${row.newer_name}`);
     console.log();
   }
 }
 
-async function cmdCheckReconcile(db: PGlite): Promise<void> {
+function cmdCheckReconcile(db: Database): void {
   const sqlPath = resolve(__dirname, "queries", "reconcile.sql");
   const sql = readFileSync(sqlPath, "utf-8");
-  const result = await db.query<{
+  const rows = db.prepare(sql).all() as {
     id: string;
     name: string;
-    predicted_files: string[];
-    actual_files: string[];
-    hits: string[];
-    misses: string[];
-    false_positives: string[];
-  }>(sql);
+    predicted_files: string;
+    actual_files: string;
+    hits: string;
+    misses: string;
+    false_positives: string;
+  }[];
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("No completed items with both predicted and actual files. Reconciliation skipped.");
     return;
   }
 
-  console.log(`Reconciliation: ${result.rows.length} item(s)\n`);
+  console.log(`Reconciliation: ${rows.length} item(s)\n`);
 
   let totalHits = 0;
   let totalMisses = 0;
   let totalFP = 0;
 
-  for (const row of result.rows) {
-    const h = row.hits.length;
-    const m = row.misses.length;
-    const fp = row.false_positives.length;
-    const denom = h + m + fp;
+  for (const row of rows) {
+    const predicted = parseJsonArray(row.predicted_files);
+    const actual = parseJsonArray(row.actual_files);
+    const hits = parseJsonArray(row.hits);
+    const misses = parseJsonArray(row.misses);
+    const fp = parseJsonArray(row.false_positives);
+    const h = hits.length;
+    const m = misses.length;
+    const fpLen = fp.length;
+    const denom = h + m + fpLen;
     const accuracy = denom === 0 ? 100 : Math.round((h / denom) * 100);
 
     totalHits += h;
     totalMisses += m;
-    totalFP += fp;
+    totalFP += fpLen;
 
     console.log(`  ${row.id}: ${row.name}`);
-    console.log(`    Predicted: ${row.predicted_files.length} files`);
-    console.log(`    Actual:    ${row.actual_files.length} files`);
-    console.log(`    Hits:      ${h}  Misses: ${m}  False pos: ${fp}  Accuracy: ${accuracy}%`);
-    if (m > 0) console.log(`    Missed:    ${row.misses.join(", ")}`);
-    if (fp > 0) console.log(`    False pos: ${row.false_positives.join(", ")}`);
+    console.log(`    Predicted: ${predicted.length} files`);
+    console.log(`    Actual:    ${actual.length} files`);
+    console.log(`    Hits:      ${h}  Misses: ${m}  False pos: ${fpLen}  Accuracy: ${accuracy}%`);
+    if (m > 0) console.log(`    Missed:    ${misses.join(", ")}`);
+    if (fpLen > 0) console.log(`    False pos: ${fp.join(", ")}`);
     console.log();
 
     // Store reconciliation in meta
-    await db.query(
+    db.prepare(
       `UPDATE work_items
-       SET meta = jsonb_set(
+       SET meta = json_set(
          meta,
-         '{reconciliation}',
-         $1::jsonb
+         '$.reconciliation',
+         json(?)
        ),
-       updated_at = now()
-       WHERE id = $2`,
-      [
-        JSON.stringify({
-          hits: row.hits,
-          misses: row.misses,
-          false_positives: row.false_positives,
-          accuracy: denom === 0 ? 1.0 : h / denom,
-          checked_at: new Date().toISOString(),
-        }),
-        row.id,
-      ]
+       updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+       WHERE id = ?`
+    ).run(
+      JSON.stringify({
+        hits,
+        misses,
+        false_positives: fp,
+        accuracy: denom === 0 ? 1.0 : h / denom,
+        checked_at: new Date().toISOString(),
+      }),
+      row.id
     );
   }
 
@@ -325,22 +315,21 @@ async function cmdCheckReconcile(db: PGlite): Promise<void> {
   console.log(`  Overall: ${totalHits} hits, ${totalMisses} misses, ${totalFP} false positives — ${overallAccuracy}% accuracy`);
 }
 
-async function cmdCheckOverlap(db: PGlite): Promise<void> {
+function cmdCheckOverlap(db: Database): void {
   const sqlPath = resolve(__dirname, "queries", "overlap.sql");
   const sql = readFileSync(sqlPath, "utf-8");
-  const result = await db.query<{
+  const rows = db.prepare(sql).all() as {
     node_a: string;
     node_b: string;
-    shared_files: string[];
-  }>(sql);
+    shared_files: string;
+  }[];
 
-  // Count frontier items
-  const frontierCount = await db.query<{ count: string }>(`
-    SELECT count(*)::text AS count
+  const frontierCount = db.prepare(`
+    SELECT count(*) AS count
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND NOT EXISTS (
         SELECT 1 FROM edges e
         JOIN work_items dep ON dep.id = e.to_id
@@ -348,61 +337,54 @@ async function cmdCheckOverlap(db: PGlite): Promise<void> {
           AND e.from_id = w.id
           AND dep.state != 'done'
       )
-  `);
+  `).get() as { count: number };
 
   console.log(`File Overlap Analysis (current frontier)\n`);
-  console.log(`  Frontier items: ${frontierCount.rows[0].count}`);
+  console.log(`  Frontier items: ${frontierCount.count}`);
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("  No overlapping file sets detected.");
     return;
   }
 
-  console.log(`  Overlapping pairs: ${result.rows.length}\n`);
+  console.log(`  Overlapping pairs: ${rows.length}\n`);
   console.log(
     `  ${pad("ITEM A", 20)} ${pad("ITEM B", 20)} SHARED FILES`
   );
   console.log(
     `  ${"─".repeat(20)} ${"─".repeat(20)} ${"─".repeat(40)}`
   );
-  for (const row of result.rows) {
+  for (const row of rows) {
+    const files = parseJsonArray(row.shared_files);
     console.log(
-      `  ${pad(row.node_a, 20)} ${pad(row.node_b, 20)} ${row.shared_files.join(", ")}`
+      `  ${pad(row.node_a, 20)} ${pad(row.node_b, 20)} ${files.join(", ")}`
     );
   }
 }
 
-async function cmdCheckDrift(db: PGlite): Promise<void> {
-  // Find files that appear as misses in multiple reconciliation records
-  const result = await db.query<{
-    id: string;
-    misses: string[];
-  }>(`
-    SELECT id, meta->'reconciliation'->'misses' AS misses
+function cmdCheckDrift(db: Database): void {
+  const rows = db.prepare(`
+    SELECT id, json_extract(meta, '$.reconciliation.misses') AS misses
     FROM work_items
-    WHERE meta->'reconciliation'->'misses' IS NOT NULL
-      AND jsonb_array_length(meta->'reconciliation'->'misses') > 0
-  `);
+    WHERE json_extract(meta, '$.reconciliation.misses') IS NOT NULL
+      AND json_array_length(json_extract(meta, '$.reconciliation.misses')) > 0
+  `).all() as { id: string; misses: string }[];
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("No reconciliation data available for drift analysis.");
     console.log("Run 'manifest check reconcile' first on items with actual_files.");
     return;
   }
 
-  // Count miss frequency across items
   const fileMissCounts: Record<string, string[]> = {};
-  for (const row of result.rows) {
-    const misses: string[] = typeof row.misses === "string"
-      ? JSON.parse(row.misses)
-      : row.misses as unknown as string[];
+  for (const row of rows) {
+    const misses = parseJsonArray(row.misses);
     for (const file of misses) {
       if (!fileMissCounts[file]) fileMissCounts[file] = [];
       fileMissCounts[file].push(row.id);
     }
   }
 
-  // Filter to files missed in 2+ items
   const driftFiles = Object.entries(fileMissCounts)
     .filter(([, ids]) => ids.length >= 2)
     .sort((a, b) => b[1].length - a[1].length);
@@ -411,7 +393,7 @@ async function cmdCheckDrift(db: PGlite): Promise<void> {
 
   if (driftFiles.length === 0) {
     console.log("  No repeated drift patterns detected (need 2+ misses for same file).");
-    console.log(`  Reconciliation data available for ${result.rows.length} item(s).`);
+    console.log(`  Reconciliation data available for ${rows.length} item(s).`);
     return;
   }
 
@@ -420,7 +402,6 @@ async function cmdCheckDrift(db: PGlite): Promise<void> {
     console.log(`    ${file}: missed in ${ids.length} items (${ids.join(", ")})`);
   }
 
-  // Record drift patterns on affected items
   const affectedItems = new Set<string>();
   const driftFileList = driftFiles.map(([f]) => f);
   for (const [, ids] of driftFiles) {
@@ -428,49 +409,44 @@ async function cmdCheckDrift(db: PGlite): Promise<void> {
   }
 
   for (const id of affectedItems) {
-    await db.query(
+    db.prepare(
       `UPDATE work_items
-       SET meta = jsonb_set(
+       SET meta = json_set(
          meta,
-         '{drift_patterns}',
-         $1::jsonb
+         '$.drift_patterns',
+         json(?)
        ),
-       updated_at = now()
-       WHERE id = $2`,
-      [
-        JSON.stringify({
-          files: driftFileList,
-          frequency: driftFiles.reduce((sum, [, ids]) =>
-            ids.includes(id) ? sum + 1 : sum, 0),
-          recorded_at: new Date().toISOString(),
-        }),
-        id,
-      ]
+       updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+       WHERE id = ?`
+    ).run(
+      JSON.stringify({
+        files: driftFileList,
+        frequency: driftFiles.reduce((sum, [, ids]) =>
+          ids.includes(id) ? sum + 1 : sum, 0),
+        recorded_at: new Date().toISOString(),
+      }),
+      id
     );
   }
 
   console.log(`\n  Drift patterns recorded on ${affectedItems.size} item(s).`);
 }
 
-async function cmdCheckNewIssues(db: PGlite): Promise<void> {
-  // List all issue_numbers currently in the manifest, grouped by repo
-  const result = await db.query<{
-    repo: string;
-    issue_number: number;
-  }>(`
+function cmdCheckNewIssues(db: Database): void {
+  const rows = db.prepare(`
     SELECT repo, issue_number
     FROM work_items
     WHERE issue_number IS NOT NULL AND repo IS NOT NULL
     ORDER BY repo, issue_number
-  `);
+  `).all() as { repo: string; issue_number: number }[];
 
-  if (result.rows.length === 0) {
+  if (rows.length === 0) {
     console.log("No issues in manifest. Run manifest-bootstrap first.");
     return;
   }
 
   const byRepo: Record<string, number[]> = {};
-  for (const row of result.rows) {
+  for (const row of rows) {
     if (!byRepo[row.repo]) byRepo[row.repo] = [];
     byRepo[row.repo].push(row.issue_number);
   }
@@ -479,40 +455,39 @@ async function cmdCheckNewIssues(db: PGlite): Promise<void> {
   for (const [repo, numbers] of Object.entries(byRepo)) {
     console.log(`  ${repo}: ${numbers.join(", ")}`);
   }
-  console.log(`\n  Total: ${result.rows.length} issue(s) across ${Object.keys(byRepo).length} repo(s)`);
+  console.log(`\n  Total: ${rows.length} issue(s) across ${Object.keys(byRepo).length} repo(s)`);
 }
 
-async function cmdCheck(db: PGlite, args: string[]): Promise<void> {
+function cmdCheck(db: Database, args: string[]): void {
   const sub = args[0];
 
   if (!sub) {
-    // Run all checks in sequence
     console.log("=== Supersession Check ===\n");
-    await cmdCheckSuperseded(db);
+    cmdCheckSuperseded(db);
     console.log("\n=== Reconciliation ===\n");
-    await cmdCheckReconcile(db);
+    cmdCheckReconcile(db);
     console.log("\n=== Overlap Analysis ===\n");
-    await cmdCheckOverlap(db);
+    cmdCheckOverlap(db);
     console.log("\n=== Drift Analysis ===\n");
-    await cmdCheckDrift(db);
+    cmdCheckDrift(db);
     return;
   }
 
   switch (sub) {
     case "superseded":
-      await cmdCheckSuperseded(db);
+      cmdCheckSuperseded(db);
       break;
     case "reconcile":
-      await cmdCheckReconcile(db);
+      cmdCheckReconcile(db);
       break;
     case "overlap":
-      await cmdCheckOverlap(db);
+      cmdCheckOverlap(db);
       break;
     case "drift":
-      await cmdCheckDrift(db);
+      cmdCheckDrift(db);
       break;
     case "new-issues":
-      await cmdCheckNewIssues(db);
+      cmdCheckNewIssues(db);
       break;
     default:
       console.error(`Unknown check subcommand: ${sub}`);
@@ -521,34 +496,30 @@ async function cmdCheck(db: PGlite, args: string[]): Promise<void> {
   }
 }
 
-async function cmdQuery(db: PGlite, args: string[]): Promise<void> {
+function cmdQuery(db: Database, args: string[]): void {
   const sql = args[0];
   if (!sql) {
     console.error("Error: query requires a SQL string.\n  manifest query \"SELECT ...\"");
     process.exit(1);
   }
-  const result = await db.query(sql);
-  if (result.rows.length === 0) {
+  const rows = db.prepare(sql).all() as Record<string, unknown>[];
+  if (rows.length === 0) {
     console.log("(0 rows)");
     return;
   }
-  const cols = Object.keys(result.rows[0] as Record<string, unknown>);
+  const cols = Object.keys(rows[0]);
   const widths = cols.map((c) =>
-    Math.max(c.length, ...result.rows.map((r) => {
-      const v = (r as Record<string, unknown>)[c];
-      return String(v ?? "NULL").length;
-    }))
+    Math.max(c.length, ...rows.map((r) => String(r[c] ?? "NULL").length))
   );
   console.log(cols.map((c, i) => pad(c, widths[i])).join("  "));
   console.log(widths.map((w) => "─".repeat(w)).join("  "));
-  for (const row of result.rows) {
-    const r = row as Record<string, unknown>;
-    console.log(cols.map((c, i) => pad(String(r[c] ?? "NULL"), widths[i])).join("  "));
+  for (const row of rows) {
+    console.log(cols.map((c, i) => pad(String(row[c] ?? "NULL"), widths[i])).join("  "));
   }
-  console.log(`\n(${result.rows.length} row${result.rows.length === 1 ? "" : "s"})`);
+  console.log(`\n(${rows.length} row${rows.length === 1 ? "" : "s"})`);
 }
 
-async function cmdInProgress(db: PGlite, args: string[]): Promise<void> {
+function cmdInProgress(db: Database, args: string[]): void {
   const id = args[0];
   const branch = args[1];
   if (!id || !branch) {
@@ -556,77 +527,88 @@ async function cmdInProgress(db: PGlite, args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const existing = await db.query<{ id: string; state: string }>(
-    "SELECT id, state FROM work_items WHERE id = $1",
-    [id]
-  );
-  if (existing.rows.length === 0) {
+  const existing = db.prepare(
+    "SELECT id, state FROM work_items WHERE id = ?"
+  ).get(id) as { id: string; state: string } | undefined;
+
+  if (!existing) {
     console.error(`Error: work item '${id}' not found.`);
     process.exit(1);
   }
-  if (existing.rows[0].state === "in_progress") {
+  if (existing.state === "in_progress") {
     console.log(`Work item '${id}' is already in_progress.`);
     return;
   }
 
-  await db.query(
-    "UPDATE work_items SET state = 'in_progress', branch = $2, updated_at = now() WHERE id = $1",
-    [id, branch]
-  );
+  db.prepare(
+    "UPDATE work_items SET state = 'in_progress', branch = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
+  ).run(branch, id);
   console.log(`Marked '${id}' as in_progress on branch '${branch}'.`);
 }
 
-async function cmdPlan(db: PGlite): Promise<void> {
-  const plan = await buildDispatchPlan(db);
+function cmdPlan(db: Database): void {
+  const plan = buildDispatchPlan(db);
   console.log(formatPlan(plan));
 }
 
 // ── Main ─────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const command = args[0];
+function main(): void {
+  const rawArgs = process.argv.slice(2);
 
+  // Parse --data-dir flag
+  let dataDir: string | undefined;
+  const args: string[] = [];
+  for (let i = 0; i < rawArgs.length; i++) {
+    if (rawArgs[i] === "--data-dir") {
+      dataDir = rawArgs[++i];
+      if (!dataDir) {
+        console.error("Error: --data-dir requires a path argument.");
+        process.exit(1);
+      }
+    } else {
+      args.push(rawArgs[i]);
+    }
+  }
+
+  const command = args[0];
   if (!command) usage();
 
-  const db = await initManifest();
+  const db = initManifest(dataDir);
 
   try {
     switch (command) {
       case "seed":
-        await cmdSeed(db, args.slice(1));
+        cmdSeed(db, args.slice(1));
         break;
       case "frontier":
-        await cmdFrontier(db);
+        cmdFrontier(db);
         break;
       case "done":
-        await cmdDone(db, args.slice(1));
+        cmdDone(db, args.slice(1));
         break;
       case "status":
-        await cmdStatus(db);
+        cmdStatus(db);
         break;
       case "check":
-        await cmdCheck(db, args.slice(1));
+        cmdCheck(db, args.slice(1));
         break;
       case "plan":
-        await cmdPlan(db);
+        cmdPlan(db);
         break;
       case "query":
-        await cmdQuery(db, args.slice(1));
+        cmdQuery(db, args.slice(1));
         break;
       case "in-progress":
-        await cmdInProgress(db, args.slice(1));
+        cmdInProgress(db, args.slice(1));
         break;
       default:
         console.error(`Unknown command: ${command}\n`);
         usage();
     }
   } finally {
-    await db.close();
+    db.close();
   }
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+main();

--- a/manifest/package-lock.json
+++ b/manifest/package-lock.json
@@ -8,19 +8,14 @@
       "name": "escapement-manifest",
       "version": "0.1.0",
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.17"
+        "better-sqlite3": "^11.0.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
         "@types/node": "^25.5.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"
       }
-    },
-    "node_modules/@electric-sql/pglite": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.17.tgz",
-      "integrity": "sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==",
-      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.4",
@@ -464,6 +459,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -472,6 +477,129 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/esbuild": {
@@ -516,6 +644,27 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -544,6 +693,164 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -552,6 +859,129 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tsx": {
@@ -574,6 +1004,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -594,6 +1036,18 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/manifest/package.json
+++ b/manifest/package.json
@@ -13,9 +13,10 @@
     "test:plan": "node --import tsx manifest/test-plan.ts"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.17"
+    "better-sqlite3": "^11.0.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^25.5.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0"

--- a/manifest/plan.ts
+++ b/manifest/plan.ts
@@ -13,7 +13,7 @@
  * See: docs/MANIFEST_SYSTEM_DESIGN_V2.md Section 11
  */
 
-import type { PGlite } from "@electric-sql/pglite";
+import type { Database } from "better-sqlite3";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -121,25 +121,35 @@ export interface HumanGatedItem {
 }
 
 // ---------------------------------------------------------------------------
-// Query functions
+// Helpers
 // ---------------------------------------------------------------------------
 
 function loadQuery(name: string): string {
   return readFileSync(resolve(__dirname, "queries", `${name}.sql`), "utf-8");
 }
 
+function parseJsonArray(v: unknown): string[] {
+  if (typeof v === "string") return JSON.parse(v);
+  if (Array.isArray(v)) return v;
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Query functions
+// ---------------------------------------------------------------------------
+
 /**
  * Query the frontier: planned items with no unmet dependencies
  * and no human gate.
  */
-export async function queryFrontier(db: PGlite): Promise<FrontierItem[]> {
+export function queryFrontier(db: Database): FrontierItem[] {
   const sql = `
     SELECT w.id, w.name, w.kind, w.repo, w.scope_hint, w.branch,
            w.issue_url, w.predicted_files
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND NOT EXISTS (
         SELECT 1
         FROM edges e
@@ -150,30 +160,37 @@ export async function queryFrontier(db: PGlite): Promise<FrontierItem[]> {
       )
     ORDER BY w.id
   `;
-  const result = await db.query<FrontierItem>(sql);
-  return result.rows;
+  const rows = db.prepare(sql).all() as (Omit<FrontierItem, "predicted_files"> & { predicted_files: string })[];
+  return rows.map((r) => ({
+    ...r,
+    predicted_files: parseJsonArray(r.predicted_files),
+  }));
 }
 
 /**
  * Detect file overlaps across frontier items.
  * Returns pairs of items that share predicted files.
  */
-export async function queryOverlaps(db: PGlite): Promise<OverlapPair[]> {
+export function queryOverlaps(db: Database): OverlapPair[] {
   const sql = loadQuery("overlap");
-  const result = await db.query<OverlapPair>(sql);
-  return result.rows;
+  const rows = db.prepare(sql).all() as { node_a: string; node_b: string; shared_files: string }[];
+  return rows.map((r) => ({
+    node_a: r.node_a,
+    node_b: r.node_b,
+    shared_files: parseJsonArray(r.shared_files),
+  }));
 }
 
 /**
  * Query blocked items: planned items with unmet dependencies.
  */
-export async function queryBlocked(db: PGlite): Promise<BlockedItem[]> {
+export function queryBlocked(db: Database): BlockedItem[] {
   const sql = `
     SELECT w.id, w.name
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND EXISTS (
         SELECT 1
         FROM edges e
@@ -184,28 +201,24 @@ export async function queryBlocked(db: PGlite): Promise<BlockedItem[]> {
       )
     ORDER BY w.id
   `;
-  const items = await db.query<{ id: string; name: string }>(sql);
+  const items = db.prepare(sql).all() as { id: string; name: string }[];
 
   const blocked: BlockedItem[] = [];
-  for (const item of items.rows) {
-    const blockerResult = await db.query<{
-      id: string;
-      name: string;
-      state: string;
-    }>(
+  for (const item of items) {
+    const blockers = db.prepare(
       `SELECT blocker.id, blocker.name, blocker.state
        FROM edges e
        JOIN work_items blocker ON blocker.id = e.to_id
        WHERE e.rel = 'depends_on'
-         AND e.from_id = $1
+         AND e.from_id = ?
          AND blocker.state != 'done'
-       ORDER BY blocker.id`,
-      [item.id]
-    );
+       ORDER BY blocker.id`
+    ).all(item.id) as { id: string; name: string; state: string }[];
+
     blocked.push({
       id: item.id,
       name: item.name,
-      blockers: blockerResult.rows,
+      blockers,
     });
   }
 
@@ -215,17 +228,16 @@ export async function queryBlocked(db: PGlite): Promise<BlockedItem[]> {
 /**
  * Query human-gated items.
  */
-export async function queryHumanGated(db: PGlite): Promise<HumanGatedItem[]> {
+export function queryHumanGated(db: Database): HumanGatedItem[] {
   const sql = `
     SELECT w.id, w.name
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = true
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) != 0
     ORDER BY w.id
   `;
-  const result = await db.query<HumanGatedItem>(sql);
-  return result.rows;
+  return db.prepare(sql).all() as HumanGatedItem[];
 }
 
 // ---------------------------------------------------------------------------
@@ -548,14 +560,14 @@ export function buildSequentialNodes(
 /**
  * Assemble the full DispatchPlan from all components.
  */
-export async function buildDispatchPlan(
-  db: PGlite,
+export function buildDispatchPlan(
+  db: Database,
   assessments?: Map<string, Assessment>
-): Promise<DispatchPlan> {
-  const frontier = await queryFrontier(db);
-  const overlaps = await queryOverlaps(db);
-  const blocked = await queryBlocked(db);
-  const humanGated = await queryHumanGated(db);
+): DispatchPlan {
+  const frontier = queryFrontier(db);
+  const overlaps = queryOverlaps(db);
+  const blocked = queryBlocked(db);
+  const humanGated = queryHumanGated(db);
 
   const groups = buildParallelGroups(frontier, overlaps, assessments);
 

--- a/manifest/queries/dependencies.sql
+++ b/manifest/queries/dependencies.sql
@@ -1,7 +1,7 @@
 -- Dependency Inspection: Blockers for a given work item
 -- See: docs/MANIFEST_SYSTEM_DESIGN_V2.md Section 9.3
 --
--- Parameter: $1 = work item id
+-- Parameter: ? = work item id
 -- Returns all items that the given work item depends on,
 -- with their current state (useful for identifying unmet blockers).
 
@@ -9,5 +9,5 @@ SELECT blocker.id, blocker.name, blocker.state
 FROM edges e
 JOIN work_items blocker ON blocker.id = e.to_id
 WHERE e.rel = 'depends_on'
-  AND e.from_id = $1
+  AND e.from_id = ?
 ORDER BY blocker.id;

--- a/manifest/queries/frontier.sql
+++ b/manifest/queries/frontier.sql
@@ -9,7 +9,7 @@ SELECT w.id, w.name, w.kind, w.repo, w.scope_hint, w.predicted_files
 FROM work_items w
 WHERE w.kind IN ('issue', 'capability')
   AND w.state = 'planned'
-  AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+  AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
   AND NOT EXISTS (
     SELECT 1
     FROM edges e

--- a/manifest/queries/overlap.sql
+++ b/manifest/queries/overlap.sql
@@ -10,8 +10,9 @@ WITH frontier AS (
   FROM work_items w
   WHERE w.kind IN ('issue', 'capability')
     AND w.state = 'planned'
-    AND w.predicted_files <> '{}'
-    AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+    AND w.predicted_files <> '[]'
+    AND w.predicted_files IS NOT NULL
+    AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
     AND NOT EXISTS (
       SELECT 1
       FROM edges e
@@ -24,15 +25,18 @@ WITH frontier AS (
 SELECT
   a.id AS node_a,
   b.id AS node_b,
-  ARRAY(
-    SELECT shared_file
+  (
+    SELECT json_group_array(af.value)
     FROM (
-      SELECT unnest(a.predicted_files) AS shared_file
-      INTERSECT
-      SELECT unnest(b.predicted_files) AS shared_file
-    ) s
-    ORDER BY shared_file
+      SELECT DISTINCT af.value
+      FROM json_each(a.predicted_files) af
+      JOIN json_each(b.predicted_files) bf ON af.value = bf.value
+      ORDER BY af.value
+    ) af
   ) AS shared_files
 FROM frontier a
 JOIN frontier b ON a.id < b.id
-WHERE a.predicted_files && b.predicted_files;
+WHERE EXISTS (
+  SELECT 1 FROM json_each(a.predicted_files) af
+  JOIN json_each(b.predicted_files) bf ON af.value = bf.value
+);

--- a/manifest/queries/progress.sql
+++ b/manifest/queries/progress.sql
@@ -24,10 +24,8 @@ WITH RECURSIVE tree AS (
 )
 SELECT
   root.name,
-  COUNT(*) FILTER (WHERE leaf.kind IN ('issue', 'capability')) AS total_items,
-  COUNT(*) FILTER (
-    WHERE leaf.kind IN ('issue', 'capability') AND leaf.state = 'done'
-  ) AS done_items
+  COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') THEN 1 END) AS total_items,
+  COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') AND leaf.state = 'done' THEN 1 END) AS done_items
 FROM tree
 JOIN work_items root ON root.id = tree.root_id
 JOIN work_items leaf ON leaf.id = tree.child_id

--- a/manifest/queries/provenance.sql
+++ b/manifest/queries/provenance.sql
@@ -1,7 +1,7 @@
 -- Provenance Query: Archive path lookup for completed items
 -- See: docs/MANIFEST_SYSTEM_DESIGN_V2.md Section 9.5
 --
--- Parameter: $1 = work item id
+-- Parameter: ? = work item id
 -- Returns the archive path for a completed item.
 -- For richer provenance, the caller reads:
 --   {archive_path}/README.md
@@ -9,5 +9,5 @@
 
 SELECT id, name, branch, archive_path
 FROM work_items
-WHERE id = $1
+WHERE id = ?
   AND archive_path IS NOT NULL;

--- a/manifest/queries/reconcile.sql
+++ b/manifest/queries/reconcile.sql
@@ -10,28 +10,43 @@ SELECT
   w.name,
   w.predicted_files,
   w.actual_files,
-  ARRAY(
-    SELECT f FROM (
-      SELECT unnest(w.predicted_files) AS f
-      INTERSECT
-      SELECT unnest(w.actual_files) AS f
-    ) h ORDER BY f
+  COALESCE(
+    (
+      SELECT json_group_array(f)
+      FROM (
+        SELECT DISTINCT pf.value AS f
+        FROM json_each(w.predicted_files) pf
+        WHERE pf.value IN (SELECT af.value FROM json_each(w.actual_files) af)
+        ORDER BY f
+      )
+    ),
+    '[]'
   ) AS hits,
-  ARRAY(
-    SELECT f FROM (
-      SELECT unnest(w.actual_files) AS f
-      EXCEPT
-      SELECT unnest(w.predicted_files) AS f
-    ) m ORDER BY f
+  COALESCE(
+    (
+      SELECT json_group_array(f)
+      FROM (
+        SELECT DISTINCT af.value AS f
+        FROM json_each(w.actual_files) af
+        WHERE af.value NOT IN (SELECT pf.value FROM json_each(w.predicted_files) pf)
+        ORDER BY f
+      )
+    ),
+    '[]'
   ) AS misses,
-  ARRAY(
-    SELECT f FROM (
-      SELECT unnest(w.predicted_files) AS f
-      EXCEPT
-      SELECT unnest(w.actual_files) AS f
-    ) fp ORDER BY f
+  COALESCE(
+    (
+      SELECT json_group_array(f)
+      FROM (
+        SELECT DISTINCT pf.value AS f
+        FROM json_each(w.predicted_files) pf
+        WHERE pf.value NOT IN (SELECT af.value FROM json_each(w.actual_files) af)
+        ORDER BY f
+      )
+    ),
+    '[]'
   ) AS false_positives
 FROM work_items w
 WHERE w.state = 'done'
-  AND w.predicted_files <> '{}'
-  AND w.actual_files <> '{}';
+  AND w.predicted_files <> '[]'
+  AND w.actual_files <> '[]';

--- a/manifest/queries/superseded.sql
+++ b/manifest/queries/superseded.sql
@@ -12,14 +12,17 @@ SELECT
   newer.id          AS newer_id,
   newer.name        AS newer_name,
   newer.scope_hint  AS newer_scope,
-  ARRAY(
-    SELECT shared_file
-    FROM (
-      SELECT unnest(older.predicted_files) AS shared_file
-      INTERSECT
-      SELECT unnest(newer.predicted_files) AS shared_file
-    ) s
-    ORDER BY shared_file
+  COALESCE(
+    (
+      SELECT json_group_array(af.value)
+      FROM (
+        SELECT DISTINCT af.value
+        FROM json_each(older.predicted_files) af
+        JOIN json_each(newer.predicted_files) bf ON af.value = bf.value
+        ORDER BY af.value
+      ) af
+    ),
+    '[]'
   ) AS shared_files
 FROM work_items older
 JOIN work_items newer
@@ -31,7 +34,10 @@ WHERE older.kind IN ('issue', 'capability')
   AND older.state = 'in_progress'
   AND (
     -- File-based overlap
-    older.predicted_files && newer.predicted_files
+    EXISTS (
+      SELECT 1 FROM json_each(older.predicted_files) af
+      JOIN json_each(newer.predicted_files) bf ON af.value = bf.value
+    )
     -- Scope-based overlap (both have scope_hint and they match)
     OR (
       older.scope_hint IS NOT NULL

--- a/manifest/schema.sql
+++ b/manifest/schema.sql
@@ -1,4 +1,4 @@
--- Manifest System V2 Schema
+-- Manifest System V2 Schema (SQLite)
 -- See: docs/MANIFEST_SYSTEM_DESIGN_V2.md Section 7.2
 
 CREATE TABLE work_items (
@@ -25,14 +25,14 @@ CREATE TABLE work_items (
     scope_hint      TEXT,
     branch          TEXT,
     archive_path    TEXT,
-    predicted_files TEXT[] DEFAULT '{}',
-    actual_files    TEXT[] DEFAULT '{}',
-    meta            JSONB NOT NULL DEFAULT '{}',
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+    predicted_files TEXT NOT NULL DEFAULT '[]',
+    actual_files    TEXT NOT NULL DEFAULT '[]',
+    meta            TEXT NOT NULL DEFAULT '{}',
+    updated_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
 
 CREATE TABLE edges (
-    id          SERIAL PRIMARY KEY,
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
     from_id     TEXT NOT NULL REFERENCES work_items(id),
     rel         TEXT NOT NULL
                 CHECK (rel IN (
@@ -43,8 +43,8 @@ CREATE TABLE edges (
     to_id       TEXT NOT NULL REFERENCES work_items(id),
     confidence  TEXT NOT NULL DEFAULT 'certain'
                 CHECK (confidence IN ('certain', 'inferred', 'ambiguous')),
-    meta        JSONB NOT NULL DEFAULT '{}',
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    meta        TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     UNIQUE (from_id, rel, to_id)
 );
 
@@ -52,8 +52,6 @@ CREATE TABLE edges (
 CREATE INDEX idx_work_items_kind ON work_items(kind);
 CREATE INDEX idx_work_items_state ON work_items(state);
 CREATE INDEX idx_work_items_repo ON work_items(repo);
-CREATE INDEX idx_work_items_predicted_files ON work_items USING gin(predicted_files);
-CREATE INDEX idx_work_items_actual_files ON work_items USING gin(actual_files);
 
 -- Indexes for edges
 CREATE INDEX idx_edges_rel ON edges(rel);

--- a/manifest/seed.ts
+++ b/manifest/seed.ts
@@ -6,11 +6,11 @@
  * along with phase and track hierarchy entities.
  *
  * Usage:
- *   node --import tsx manifest/seed.ts          # seed real PGlite
+ *   node --import tsx manifest/seed.ts          # seed real SQLite DB
  *   import { seed } from "./seed.ts"            # programmatic use
  */
 
-import type { PGlite } from "@electric-sql/pglite";
+import type { Database } from "better-sqlite3";
 import { initManifest } from "./init.ts";
 
 // ---------------------------------------------------------------------------
@@ -231,56 +231,58 @@ const hierarchyEdges: Edge[] = [
 // ---------------------------------------------------------------------------
 
 /**
- * Insert all manifest work items and edges into the given PGlite instance.
+ * Insert all manifest work items and edges into the given SQLite instance.
  * Uses INSERT ... ON CONFLICT DO NOTHING for idempotency.
  */
-export async function seed(db: PGlite): Promise<{
+export function seed(db: Database): {
   itemsInserted: number;
   edgesInserted: number;
-}> {
+} {
   const allItems: WorkItem[] = [phase, ...tracks, ...issues];
   const allEdges: Edge[] = [...dependencyEdges, ...hierarchyEdges];
 
   let itemsInserted = 0;
   let edgesInserted = 0;
 
+  const insertItem = db.prepare(
+    `INSERT INTO work_items (id, name, kind, state, repo, issue_number, issue_url, predicted_files, meta)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (id) DO NOTHING`
+  );
+
+  const insertEdge = db.prepare(
+    `INSERT INTO edges (from_id, rel, to_id, confidence)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT (from_id, rel, to_id) DO NOTHING`
+  );
+
   // Insert work items
   for (const item of allItems) {
-    const result = await db.query(
-      `INSERT INTO work_items (id, name, kind, state, repo, issue_number, issue_url, predicted_files, meta)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-       ON CONFLICT (id) DO NOTHING`,
-      [
-        item.id,
-        item.name,
-        item.kind,
-        item.state,
-        item.repo ?? null,
-        item.issue_number ?? null,
-        item.issue_url ?? null,
-        item.predicted_files ?? [],
-        item.meta ? JSON.stringify(item.meta) : "{}",
-      ]
+    const result = insertItem.run(
+      item.id,
+      item.name,
+      item.kind,
+      item.state,
+      item.repo ?? null,
+      item.issue_number ?? null,
+      item.issue_url ?? null,
+      JSON.stringify(item.predicted_files ?? []),
+      item.meta ? JSON.stringify(item.meta) : "{}",
     );
-    if (result.affectedRows && result.affectedRows > 0) {
+    if (result.changes > 0) {
       itemsInserted++;
     }
   }
 
   // Insert edges
   for (const edge of allEdges) {
-    const result = await db.query(
-      `INSERT INTO edges (from_id, rel, to_id, confidence)
-       VALUES ($1, $2, $3, $4)
-       ON CONFLICT (from_id, rel, to_id) DO NOTHING`,
-      [
-        edge.from_id,
-        edge.rel,
-        edge.to_id,
-        edge.confidence ?? "certain",
-      ]
+    const result = insertEdge.run(
+      edge.from_id,
+      edge.rel,
+      edge.to_id,
+      edge.confidence ?? "certain",
     );
-    if (result.affectedRows && result.affectedRows > 0) {
+    if (result.changes > 0) {
       edgesInserted++;
     }
   }
@@ -297,10 +299,10 @@ const isMain =
   process.argv[1]?.endsWith("/seed.js");
 
 if (isMain) {
-  const db = await initManifest();
-  const result = await seed(db);
+  const db = initManifest();
+  const result = seed(db);
   console.log(
     `Manifest seeded: ${result.itemsInserted} work items, ${result.edgesInserted} edges`
   );
-  await db.close();
+  db.close();
 }

--- a/manifest/test-check.ts
+++ b/manifest/test-check.ts
@@ -1,4 +1,4 @@
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,13 +15,19 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  *   - new-issues: list manifest issue numbers
  */
 
-async function assert(condition: boolean, msg: string) {
+function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(`FAIL: ${msg}`);
-  console.log(`  ✓ ${msg}`);
+  console.log(`  \u2713 ${msg}`);
 }
 
-async function seedCheckTestData(db: PGlite) {
-  await db.exec(`
+function parseJsonArray(v: unknown): string[] {
+  if (typeof v === "string") return JSON.parse(v);
+  if (Array.isArray(v)) return v;
+  return [];
+}
+
+function seedCheckTestData(db: Database.Database) {
+  db.exec(`
     -- Phase/track structure
     INSERT INTO work_items (id, name, kind, state) VALUES
       ('phase:core', 'Phase 1: Core', 'phase', 'planned'),
@@ -39,9 +45,9 @@ async function seedCheckTestData(db: PGlite) {
       'test-org/test-repo',
       10,
       'https://github.com/test-org/test-repo/issues/10',
-      ARRAY['src/widget.ts', 'src/utils.ts'],
-      '{}',
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb,
+      '["src/widget.ts", "src/utils.ts"]',
+      '[]',
+      '{"bootstrap_status":"active","needs_human":false}',
       '2026-01-01T00:00:00Z'
     );
 
@@ -57,8 +63,8 @@ async function seedCheckTestData(db: PGlite) {
       'test-org/test-repo',
       20,
       'https://github.com/test-org/test-repo/issues/20',
-      ARRAY['src/widget.ts', 'src/widget-v2.ts'],
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb,
+      '["src/widget.ts", "src/widget-v2.ts"]',
+      '{"bootstrap_status":"active","needs_human":false}',
       '2026-03-01T00:00:00Z'
     );
 
@@ -74,9 +80,9 @@ async function seedCheckTestData(db: PGlite) {
       'test-org/test-repo',
       5,
       'https://github.com/test-org/test-repo/issues/5',
-      ARRAY['src/db.ts', 'src/model.ts', 'src/config.ts'],
-      ARRAY['src/db.ts', 'src/model.ts', 'src/migrations.ts'],
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb
+      '["src/db.ts", "src/model.ts", "src/config.ts"]',
+      '["src/db.ts", "src/model.ts", "src/migrations.ts"]',
+      '{"bootstrap_status":"active","needs_human":false}'
     );
 
     -- Another done item with reconciliation data (for drift testing)
@@ -91,9 +97,9 @@ async function seedCheckTestData(db: PGlite) {
       'test-org/test-repo',
       6,
       'https://github.com/test-org/test-repo/issues/6',
-      ARRAY['src/auth.ts', 'src/middleware.ts'],
-      ARRAY['src/auth.ts', 'src/middleware.ts', 'src/migrations.ts', 'src/config.ts'],
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb
+      '["src/auth.ts", "src/middleware.ts"]',
+      '["src/auth.ts", "src/middleware.ts", "src/migrations.ts", "src/config.ts"]',
+      '{"bootstrap_status":"active","needs_human":false}'
     );
 
     -- A frontier item with no overlap (isolated)
@@ -108,8 +114,8 @@ async function seedCheckTestData(db: PGlite) {
       'test-org/test-repo',
       30,
       'https://github.com/test-org/test-repo/issues/30',
-      ARRAY['docs/README.md'],
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb
+      '["docs/README.md"]',
+      '{"bootstrap_status":"active","needs_human":false}'
     );
 
     -- Edges
@@ -123,13 +129,14 @@ async function seedCheckTestData(db: PGlite) {
   `);
 }
 
-async function run() {
+function run() {
   console.log("Manifest check subcommand tests\n");
 
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
-  await seedCheckTestData(db);
-  console.log("  ✓ Test data seeded\n");
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
+  seedCheckTestData(db);
+  console.log("  \u2713 Test data seeded\n");
 
   // ── Test 1: Supersession detection ──────────────────────────────
   console.log("1. Supersession detection (SQL query)");
@@ -138,27 +145,28 @@ async function run() {
     resolve(__dirname, "queries", "superseded.sql"),
     "utf-8"
   );
-  const superseded = await db.query<{
+  const superseded = db.prepare(supersededSql).all() as {
     older_id: string;
     newer_id: string;
-    shared_files: string[];
-  }>(supersededSql);
+    shared_files: string;
+  }[];
 
-  await assert(superseded.rows.length === 1, "Exactly 1 supersession pair detected");
-  await assert(
-    superseded.rows[0].older_id === "test#10",
+  assert(superseded.length === 1, "Exactly 1 supersession pair detected");
+  assert(
+    superseded[0].older_id === "test#10",
     "Older item is test#10 (in_progress)"
   );
-  await assert(
-    superseded.rows[0].newer_id === "test#20",
+  assert(
+    superseded[0].newer_id === "test#20",
     "Newer item is test#20 (planned, overlapping files)"
   );
-  await assert(
-    superseded.rows[0].shared_files.includes("src/widget.ts"),
+  const supersededFiles = parseJsonArray(superseded[0].shared_files);
+  assert(
+    supersededFiles.includes("src/widget.ts"),
     "Shared file src/widget.ts detected"
   );
-  await assert(
-    superseded.rows[0].shared_files.length === 1,
+  assert(
+    supersededFiles.length === 1,
     "Only 1 shared file (src/widget.ts)"
   );
 
@@ -169,42 +177,47 @@ async function run() {
     resolve(__dirname, "queries", "reconcile.sql"),
     "utf-8"
   );
-  const reconcile = await db.query<{
+  const reconcile = db.prepare(reconcileSql).all() as {
     id: string;
-    hits: string[];
-    misses: string[];
-    false_positives: string[];
-  }>(reconcileSql);
+    hits: string;
+    misses: string;
+    false_positives: string;
+  }[];
 
-  await assert(reconcile.rows.length === 2, "2 items eligible for reconciliation");
+  assert(reconcile.length === 2, "2 items eligible for reconciliation");
 
-  const item5 = reconcile.rows.find((r) => r.id === "test#5");
-  await assert(item5 !== undefined, "test#5 found in reconciliation");
-  await assert(
-    item5!.hits.length === 2,
+  const item5 = reconcile.find((r) => r.id === "test#5");
+  assert(item5 !== undefined, "test#5 found in reconciliation");
+  const item5hits = parseJsonArray(item5!.hits);
+  const item5misses = parseJsonArray(item5!.misses);
+  const item5fp = parseJsonArray(item5!.false_positives);
+  assert(
+    item5hits.length === 2,
     "test#5 has 2 hits (src/db.ts, src/model.ts)"
   );
-  await assert(
-    item5!.misses.includes("src/migrations.ts"),
+  assert(
+    item5misses.includes("src/migrations.ts"),
     "test#5 missed src/migrations.ts"
   );
-  await assert(
-    item5!.false_positives.includes("src/config.ts"),
+  assert(
+    item5fp.includes("src/config.ts"),
     "test#5 false positive: src/config.ts"
   );
 
-  const item6 = reconcile.rows.find((r) => r.id === "test#6");
-  await assert(item6 !== undefined, "test#6 found in reconciliation");
-  await assert(
-    item6!.hits.length === 2,
+  const item6 = reconcile.find((r) => r.id === "test#6");
+  assert(item6 !== undefined, "test#6 found in reconciliation");
+  const item6hits = parseJsonArray(item6!.hits);
+  const item6misses = parseJsonArray(item6!.misses);
+  assert(
+    item6hits.length === 2,
     "test#6 has 2 hits (src/auth.ts, src/middleware.ts)"
   );
-  await assert(
-    item6!.misses.includes("src/migrations.ts"),
+  assert(
+    item6misses.includes("src/migrations.ts"),
     "test#6 missed src/migrations.ts"
   );
-  await assert(
-    item6!.misses.includes("src/config.ts"),
+  assert(
+    item6misses.includes("src/config.ts"),
     "test#6 missed src/config.ts"
   );
 
@@ -215,22 +228,19 @@ async function run() {
     resolve(__dirname, "queries", "overlap.sql"),
     "utf-8"
   );
-  const overlap = await db.query<{
+  const overlap = db.prepare(overlapSql).all() as {
     node_a: string;
     node_b: string;
-    shared_files: string[];
-  }>(overlapSql);
+    shared_files: string;
+  }[];
 
-  // test#20 (planned, frontier) and test#30 (planned, frontier) have no overlap
-  // test#20 shares src/widget.ts with test#10, but test#10 is in_progress not planned
-  // So the frontier overlap check only considers planned items
-  await assert(
-    overlap.rows.length === 0,
+  assert(
+    overlap.length === 0,
     "No overlap among frontier items (test#20 and test#30 have disjoint files)"
   );
 
   // Add another frontier item that overlaps with test#20
-  await db.exec(`
+  db.exec(`
     INSERT INTO work_items (
       id, name, kind, state, predicted_files, meta
     ) VALUES (
@@ -238,74 +248,67 @@ async function run() {
       'Widget tests',
       'issue',
       'planned',
-      ARRAY['src/widget.ts', 'tests/widget.test.ts'],
-      '{"needs_human":false}'::jsonb
+      '["src/widget.ts", "tests/widget.test.ts"]',
+      '{"needs_human":false}'
     )
   `);
 
-  const overlap2 = await db.query<{
+  const overlap2 = db.prepare(overlapSql).all() as {
     node_a: string;
     node_b: string;
-    shared_files: string[];
-  }>(overlapSql);
+    shared_files: string;
+  }[];
 
-  await assert(overlap2.rows.length === 1, "1 overlap pair after adding test#21");
-  await assert(
-    overlap2.rows[0].shared_files.includes("src/widget.ts"),
+  assert(overlap2.length === 1, "1 overlap pair after adding test#21");
+  const overlap2Files = parseJsonArray(overlap2[0].shared_files);
+  assert(
+    overlap2Files.includes("src/widget.ts"),
     "Overlap is on src/widget.ts"
   );
 
   // ── Test 4: Drift detection ────────────────────────────────────
   console.log("\n4. Drift detection");
 
-  // First, simulate reconciliation being stored in meta (as the CLI reconcile command does)
-  await db.query(
-    `UPDATE work_items SET meta = jsonb_set(meta, '{reconciliation}', $1::jsonb) WHERE id = $2`,
-    [
-      JSON.stringify({
-        hits: ["src/db.ts", "src/model.ts"],
-        misses: ["src/migrations.ts"],
-        false_positives: ["src/config.ts"],
-        accuracy: 0.5,
-        checked_at: new Date().toISOString(),
-      }),
-      "test#5",
-    ]
+  // Simulate reconciliation being stored in meta
+  db.prepare(
+    `UPDATE work_items SET meta = json_set(meta, '$.reconciliation', json(?)) WHERE id = ?`
+  ).run(
+    JSON.stringify({
+      hits: ["src/db.ts", "src/model.ts"],
+      misses: ["src/migrations.ts"],
+      false_positives: ["src/config.ts"],
+      accuracy: 0.5,
+      checked_at: new Date().toISOString(),
+    }),
+    "test#5"
   );
-  await db.query(
-    `UPDATE work_items SET meta = jsonb_set(meta, '{reconciliation}', $1::jsonb) WHERE id = $2`,
-    [
-      JSON.stringify({
-        hits: ["src/auth.ts", "src/middleware.ts"],
-        misses: ["src/migrations.ts", "src/config.ts"],
-        false_positives: [],
-        accuracy: 0.5,
-        checked_at: new Date().toISOString(),
-      }),
-      "test#6",
-    ]
+  db.prepare(
+    `UPDATE work_items SET meta = json_set(meta, '$.reconciliation', json(?)) WHERE id = ?`
+  ).run(
+    JSON.stringify({
+      hits: ["src/auth.ts", "src/middleware.ts"],
+      misses: ["src/migrations.ts", "src/config.ts"],
+      false_positives: [],
+      accuracy: 0.5,
+      checked_at: new Date().toISOString(),
+    }),
+    "test#6"
   );
 
   // Now query for drift (files missed in 2+ items)
-  const driftResult = await db.query<{
-    id: string;
-    misses: unknown;
-  }>(`
-    SELECT id, meta->'reconciliation'->'misses' AS misses
+  const driftResult = db.prepare(`
+    SELECT id, json_extract(meta, '$.reconciliation.misses') AS misses
     FROM work_items
-    WHERE meta->'reconciliation'->'misses' IS NOT NULL
-      AND jsonb_array_length(meta->'reconciliation'->'misses') > 0
-  `);
+    WHERE json_extract(meta, '$.reconciliation.misses') IS NOT NULL
+      AND json_array_length(json_extract(meta, '$.reconciliation.misses')) > 0
+  `).all() as { id: string; misses: string }[];
 
-  await assert(driftResult.rows.length === 2, "2 items have reconciliation misses");
+  assert(driftResult.length === 2, "2 items have reconciliation misses");
 
   // Compute drift frequency
   const fileMissCounts: Record<string, string[]> = {};
-  for (const row of driftResult.rows) {
-    const misses: string[] =
-      typeof row.misses === "string"
-        ? JSON.parse(row.misses)
-        : (row.misses as string[]);
+  for (const row of driftResult) {
+    const misses = parseJsonArray(row.misses);
     for (const file of misses) {
       if (!fileMissCounts[file]) fileMissCounts[file] = [];
       fileMissCounts[file].push(row.id);
@@ -316,12 +319,12 @@ async function run() {
     ([, ids]) => ids.length >= 2
   );
 
-  await assert(driftFiles.length === 1, "1 drift file detected (src/migrations.ts)");
-  await assert(
+  assert(driftFiles.length === 1, "1 drift file detected (src/migrations.ts)");
+  assert(
     driftFiles[0][0] === "src/migrations.ts",
     "Drift file is src/migrations.ts"
   );
-  await assert(
+  assert(
     driftFiles[0][1].length === 2,
     "src/migrations.ts missed in 2 items"
   );
@@ -329,28 +332,25 @@ async function run() {
   // ── Test 5: New issues listing ─────────────────────────────────
   console.log("\n5. New issues listing");
 
-  const newIssues = await db.query<{
-    repo: string;
-    issue_number: number;
-  }>(`
+  const newIssues = db.prepare(`
     SELECT repo, issue_number
     FROM work_items
     WHERE issue_number IS NOT NULL AND repo IS NOT NULL
     ORDER BY repo, issue_number
-  `);
+  `).all() as { repo: string; issue_number: number }[];
 
-  await assert(newIssues.rows.length === 5, "5 issues with issue_number in manifest");
-  const numbers = newIssues.rows.map((r) => r.issue_number);
-  await assert(numbers.includes(5), "Issue #5 present");
-  await assert(numbers.includes(6), "Issue #6 present");
-  await assert(numbers.includes(10), "Issue #10 present");
-  await assert(numbers.includes(20), "Issue #20 present");
-  await assert(numbers.includes(30), "Issue #30 present");
+  assert(newIssues.length === 5, "5 issues with issue_number in manifest");
+  const numbers = newIssues.map((r) => r.issue_number);
+  assert(numbers.includes(5), "Issue #5 present");
+  assert(numbers.includes(6), "Issue #6 present");
+  assert(numbers.includes(10), "Issue #10 present");
+  assert(numbers.includes(20), "Issue #20 present");
+  assert(numbers.includes(30), "Issue #30 present");
 
   // ── Test 6: Supersession with scope_hint match ─────────────────
   console.log("\n6. Supersession via scope_hint (no file overlap)");
 
-  await db.exec(`
+  db.exec(`
     INSERT INTO work_items (
       id, name, kind, state, scope_hint,
       predicted_files, meta, updated_at
@@ -360,8 +360,8 @@ async function run() {
       'issue',
       'in_progress',
       'auth-system',
-      ARRAY['src/old-auth.ts'],
-      '{"needs_human":false}'::jsonb,
+      '["src/old-auth.ts"]',
+      '{"needs_human":false}',
       '2026-01-15T00:00:00Z'
     ), (
       'test#50',
@@ -369,33 +369,36 @@ async function run() {
       'issue',
       'planned',
       'auth-system',
-      ARRAY['src/new-auth.ts'],
-      '{"needs_human":false}'::jsonb,
+      '["src/new-auth.ts"]',
+      '{"needs_human":false}',
       '2026-03-15T00:00:00Z'
     )
   `);
 
-  const superseded2 = await db.query<{
+  const superseded2 = db.prepare(supersededSql).all() as {
     older_id: string;
     newer_id: string;
-    shared_files: string[];
-  }>(supersededSql);
+    shared_files: string;
+  }[];
 
-  const scopeMatch = superseded2.rows.find(
+  const scopeMatch = superseded2.find(
     (r) => r.older_id === "test#40" && r.newer_id === "test#50"
   );
-  await assert(scopeMatch !== undefined, "Scope-based supersession detected (test#40 -> test#50)");
-  await assert(
-    scopeMatch!.shared_files.length === 0,
+  assert(scopeMatch !== undefined, "Scope-based supersession detected (test#40 -> test#50)");
+  const scopeFiles = parseJsonArray(scopeMatch!.shared_files);
+  assert(
+    scopeFiles.length === 0,
     "No shared files (supersession is scope-based)"
   );
 
   // ── Done ────────────────────────────────────────────────────────
-  await db.close();
+  db.close();
   console.log("\nAll tests passed.");
 }
 
-run().catch((err) => {
+try {
+  run();
+} catch (err: any) {
   console.error(err);
   process.exit(1);
-});
+}

--- a/manifest/test-cli.ts
+++ b/manifest/test-cli.ts
@@ -1,21 +1,21 @@
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { applySchema } from "./init.ts";
 
 /**
  * Smoke tests for manifest CLI queries.
  *
  * Instead of spawning the CLI as a subprocess, we test the core SQL queries
- * directly against an in-memory PGlite instance with the example seed data
+ * directly against an in-memory SQLite instance with the example seed data
  * from V2 design doc Section 15.
  */
 
-async function assert(condition: boolean, msg: string) {
+function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(`FAIL: ${msg}`);
-  console.log(`  ✓ ${msg}`);
+  console.log(`  \u2713 ${msg}`);
 }
 
-async function seedTestData(db: PGlite) {
-  await db.exec(`
+function seedTestData(db: Database.Database) {
+  db.exec(`
     INSERT INTO work_items (id, name, kind, state) VALUES
       ('phase:test_infra', 'Phase 1: Test Infrastructure', 'phase', 'planned'),
       ('track:phase1:api', 'API Layer', 'track', 'planned');
@@ -31,8 +31,8 @@ async function seedTestData(db: PGlite) {
         'test-repo',
         1,
         'https://github.com/test/repo/issues/1',
-        ARRAY['src/model.ts'],
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["src/model.ts"]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'test#2',
@@ -42,8 +42,8 @@ async function seedTestData(db: PGlite) {
         'test-repo',
         2,
         'https://github.com/test/repo/issues/2',
-        ARRAY['src/api.ts', 'src/model.ts'],
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["src/api.ts", "src/model.ts"]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'test#3',
@@ -53,8 +53,8 @@ async function seedTestData(db: PGlite) {
         'test-repo',
         3,
         'https://github.com/test/repo/issues/3',
-        ARRAY['tests/api.test.ts'],
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["tests/api.test.ts"]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'test#4',
@@ -64,8 +64,8 @@ async function seedTestData(db: PGlite) {
         'test-repo',
         4,
         'https://github.com/test/repo/issues/4',
-        '{}',
-        '{"needs_human":true}'::jsonb
+        '[]',
+        '{"needs_human":true}'
       );
 
     INSERT INTO edges (from_id, rel, to_id, confidence) VALUES
@@ -78,23 +78,24 @@ async function seedTestData(db: PGlite) {
   `);
 }
 
-async function run() {
+function run() {
   console.log("Manifest CLI query smoke tests\n");
 
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
-  await seedTestData(db);
-  console.log("  ✓ Test data seeded\n");
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
+  seedTestData(db);
+  console.log("  \u2713 Test data seeded\n");
 
   // ── Test 1: Frontier query ───────────────────────────────────────
   console.log("1. Frontier query");
 
-  const frontier = await db.query<{ id: string; name: string }>(`
+  const frontier = db.prepare(`
     SELECT w.id, w.name
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND NOT EXISTS (
         SELECT 1
         FROM edges e
@@ -104,32 +105,28 @@ async function run() {
           AND dep.state != 'done'
       )
     ORDER BY w.id
-  `);
+  `).all() as { id: string; name: string }[];
 
-  const frontierIds = frontier.rows.map((r) => r.id);
-  // test#1 is done, test#2 depends on test#1 (done) so it IS dispatchable
-  // test#3 depends on test#2 (planned) so it is NOT dispatchable
-  // test#4 needs_human=true so it is NOT dispatchable
-  await assert(frontierIds.includes("test#2"), "test#2 is on frontier (dep test#1 is done)");
-  await assert(!frontierIds.includes("test#1"), "test#1 excluded (already done)");
-  await assert(!frontierIds.includes("test#3"), "test#3 excluded (dep test#2 not done)");
-  await assert(!frontierIds.includes("test#4"), "test#4 excluded (needs_human=true)");
-  await assert(frontierIds.length === 1, "Exactly 1 frontier item");
+  const frontierIds = frontier.map((r) => r.id);
+  assert(frontierIds.includes("test#2"), "test#2 is on frontier (dep test#1 is done)");
+  assert(!frontierIds.includes("test#1"), "test#1 excluded (already done)");
+  assert(!frontierIds.includes("test#3"), "test#3 excluded (dep test#2 not done)");
+  assert(!frontierIds.includes("test#4"), "test#4 excluded (needs_human=true)");
+  assert(frontierIds.length === 1, "Exactly 1 frontier item");
 
   // ── Test 2: Mark done and recompute frontier ─────────────────────
   console.log("\n2. Mark done + frontier recompute");
 
-  await db.query(
-    "UPDATE work_items SET state = 'done', updated_at = now() WHERE id = $1",
-    ["test#2"]
-  );
+  db.prepare(
+    "UPDATE work_items SET state = 'done', updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE id = ?"
+  ).run("test#2");
 
-  const frontier2 = await db.query<{ id: string }>(`
+  const frontier2 = db.prepare(`
     SELECT w.id
     FROM work_items w
     WHERE w.kind IN ('issue', 'capability')
       AND w.state = 'planned'
-      AND COALESCE((w.meta->>'needs_human')::boolean, false) = false
+      AND COALESCE(json_extract(w.meta, '$.needs_human'), 0) = 0
       AND NOT EXISTS (
         SELECT 1
         FROM edges e
@@ -139,20 +136,16 @@ async function run() {
           AND dep.state != 'done'
       )
     ORDER BY w.id
-  `);
+  `).all() as { id: string }[];
 
-  const frontier2Ids = frontier2.rows.map((r) => r.id);
-  await assert(frontier2Ids.includes("test#3"), "test#3 now on frontier after test#2 done");
-  await assert(!frontier2Ids.includes("test#2"), "test#2 no longer on frontier (now done)");
+  const frontier2Ids = frontier2.map((r) => r.id);
+  assert(frontier2Ids.includes("test#3"), "test#3 now on frontier after test#2 done");
+  assert(!frontier2Ids.includes("test#2"), "test#2 no longer on frontier (now done)");
 
   // ── Test 3: Hierarchical status rollup ───────────────────────────
   console.log("\n3. Status rollup");
 
-  const rollup = await db.query<{
-    name: string;
-    total_items: string;
-    done_items: string;
-  }>(`
+  const rollup = db.prepare(`
     WITH RECURSIVE tree AS (
       SELECT
         parent.id AS root_id,
@@ -173,50 +166,48 @@ async function run() {
     )
     SELECT
       root.name,
-      COUNT(*) FILTER (WHERE leaf.kind IN ('issue', 'capability'))::text AS total_items,
-      COUNT(*) FILTER (
-        WHERE leaf.kind IN ('issue', 'capability') AND leaf.state = 'done'
-      )::text AS done_items
+      COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') THEN 1 END) AS total_items,
+      COUNT(CASE WHEN leaf.kind IN ('issue', 'capability') AND leaf.state = 'done' THEN 1 END) AS done_items
     FROM tree
     JOIN work_items root ON root.id = tree.root_id
     JOIN work_items leaf ON leaf.id = tree.child_id
     GROUP BY root.id, root.name
     ORDER BY root.name
-  `);
+  `).all() as { name: string; total_items: number; done_items: number }[];
 
   // Track has 3 direct issues (test#1, test#2, test#3); test#4 not part of track
-  const track = rollup.rows.find((r) => r.name === "API Layer");
-  await assert(track !== undefined, "API Layer track found in rollup");
-  await assert(track!.total_items === "3", "Track has 3 total issue items");
-  await assert(track!.done_items === "2", "Track has 2 done items (test#1, test#2)");
+  const track = rollup.find((r) => r.name === "API Layer");
+  assert(track !== undefined, "API Layer track found in rollup");
+  assert(track!.total_items === 3, "Track has 3 total issue items");
+  assert(track!.done_items === 2, "Track has 2 done items (test#1, test#2)");
 
   // Phase rolls up through track, so it should see the same leaf items
-  const phase = rollup.rows.find((r) => r.name === "Phase 1: Test Infrastructure");
-  await assert(phase !== undefined, "Phase found in rollup");
-  await assert(phase!.total_items === "3", "Phase has 3 total items (via track)");
-  await assert(phase!.done_items === "2", "Phase has 2 done items (via track)");
+  const phase = rollup.find((r) => r.name === "Phase 1: Test Infrastructure");
+  assert(phase !== undefined, "Phase found in rollup");
+  assert(phase!.total_items === 3, "Phase has 3 total items (via track)");
+  assert(phase!.done_items === 2, "Phase has 2 done items (via track)");
 
   // ── Test 4: Item not found handling ──────────────────────────────
   console.log("\n4. Edge cases");
 
-  const missing = await db.query<{ id: string }>(
-    "SELECT id FROM work_items WHERE id = $1",
-    ["nonexistent"]
-  );
-  await assert(missing.rows.length === 0, "Nonexistent item returns empty result");
+  const missing = db.prepare(
+    "SELECT id FROM work_items WHERE id = ?"
+  ).all("nonexistent") as { id: string }[];
+  assert(missing.length === 0, "Nonexistent item returns empty result");
 
-  const alreadyDone = await db.query<{ state: string }>(
-    "SELECT state FROM work_items WHERE id = $1",
-    ["test#1"]
-  );
-  await assert(alreadyDone.rows[0].state === "done", "test#1 state is 'done'");
+  const alreadyDone = db.prepare(
+    "SELECT state FROM work_items WHERE id = ?"
+  ).get("test#1") as { state: string };
+  assert(alreadyDone.state === "done", "test#1 state is 'done'");
 
   // ── Done ─────────────────────────────────────────────────────────
-  await db.close();
+  db.close();
   console.log("\nAll tests passed.");
 }
 
-run().catch((err) => {
+try {
+  run();
+} catch (err: any) {
   console.error(err);
   process.exit(1);
-});
+}

--- a/manifest/test-plan.ts
+++ b/manifest/test-plan.ts
@@ -1,7 +1,7 @@
 /**
  * test-plan.ts -- Tests for the manifest dispatch planner.
  *
- * Uses the same in-memory PGlite + mock data pattern as test-queries.ts.
+ * Uses the same in-memory SQLite + mock data pattern as test-queries.ts.
  * Verifies:
  *   1. queryFrontier returns correct items
  *   2. queryOverlaps detects shared files
@@ -16,7 +16,7 @@
  *  11. Multi-repo grouping partitions correctly
  */
 
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { applySchema } from "./init.ts";
 import {
   queryFrontier,
@@ -33,11 +33,9 @@ import {
   formatPlan,
   overlapKey,
   type Assessment,
-  type FrontierItem,
-  type OverlapPair,
 } from "./plan.ts";
 
-async function assert(condition: boolean, msg: string) {
+function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(`FAIL: ${msg}`);
   console.log(`  \u2713 ${msg}`);
 }
@@ -58,8 +56,8 @@ async function assert(condition: boolean, msg: string) {
  *
  *   esc#11 and esc#13 share 'shared/utils.ts'
  */
-async function seed(db: PGlite) {
-  await db.exec(`
+function seed(db: Database.Database) {
+  db.exec(`
     INSERT INTO work_items (
       id, name, kind, state, repo, issue_number, issue_url,
       branch, predicted_files, meta
@@ -69,55 +67,55 @@ async function seed(db: PGlite) {
         'fusupo/escapement', 10,
         'https://github.com/fusupo/escapement/issues/10',
         '10-schema-setup',
-        ARRAY['manifest/schema.sql', 'manifest/init.ts'],
-        '{}'::jsonb
+        '["manifest/schema.sql", "manifest/init.ts"]',
+        '{}'
       ),
       (
         'esc#11', 'Core queries', 'issue', 'planned',
         'fusupo/escapement', 11,
         'https://github.com/fusupo/escapement/issues/11',
         '11-core-queries',
-        ARRAY['manifest/queries/frontier.sql', 'shared/utils.ts'],
-        '{}'::jsonb
+        '["manifest/queries/frontier.sql", "shared/utils.ts"]',
+        '{}'
       ),
       (
         'esc#12', 'Bootstrap CLI', 'issue', 'planned',
         'fusupo/escapement', 12,
         'https://github.com/fusupo/escapement/issues/12',
         NULL,
-        ARRAY['manifest/bootstrap.ts'],
-        '{}'::jsonb
+        '["manifest/bootstrap.ts"]',
+        '{}'
       ),
       (
         'esc#13', 'UI components', 'issue', 'planned',
         'fusupo/escapement', 13,
         'https://github.com/fusupo/escapement/issues/13',
         '13-ui-components',
-        ARRAY['src/components/Dashboard.tsx', 'shared/utils.ts'],
-        '{}'::jsonb
+        '["src/components/Dashboard.tsx", "shared/utils.ts"]',
+        '{}'
       ),
       (
         'esc#14', 'Design review', 'issue', 'planned',
         'fusupo/escapement', 14,
         'https://github.com/fusupo/escapement/issues/14',
         NULL,
-        ARRAY['docs/design.md'],
-        '{"needs_human":true}'::jsonb
+        '["docs/design.md"]',
+        '{"needs_human":true}'
       ),
       (
         'esc#15', 'Deprecate construct', 'capability', 'planned',
         'fusupo/escapement', NULL, NULL,
         NULL,
-        '{}',
-        '{}'::jsonb
+        '[]',
+        '{}'
       ),
       (
         'other#1', 'Other repo task', 'issue', 'planned',
         'fusupo/other-repo', 1,
         'https://github.com/fusupo/other-repo/issues/1',
         '1-other-task',
-        ARRAY['src/main.ts', 'shared/utils.ts'],
-        '{}'::jsonb
+        '["src/main.ts", "shared/utils.ts"]',
+        '{}'
       );
 
     INSERT INTO edges (from_id, rel, to_id, confidence) VALUES
@@ -126,64 +124,65 @@ async function seed(db: PGlite) {
   `);
 }
 
-async function run() {
+function run() {
   console.log("Manifest plan tests\n");
 
   // Setup
   console.log("0. Setup");
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
-  await seed(db);
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
+  seed(db);
   console.log("  \u2713 Schema applied and data seeded\n");
 
   // ─── 1. queryFrontier ─────────────────────────────────────────────
   console.log("1. queryFrontier");
-  const frontier = await queryFrontier(db);
+  const frontier = queryFrontier(db);
   const frontierIds = frontier.map((f) => f.id).sort();
 
-  await assert(frontierIds.includes("esc#11"), "esc#11 on frontier (dep met)");
-  await assert(frontierIds.includes("esc#13"), "esc#13 on frontier (no deps)");
-  await assert(frontierIds.includes("esc#15"), "esc#15 on frontier (capability, no deps)");
-  await assert(frontierIds.includes("other#1"), "other#1 on frontier (different repo, no deps)");
-  await assert(!frontierIds.includes("esc#10"), "esc#10 excluded (done)");
-  await assert(!frontierIds.includes("esc#12"), "esc#12 excluded (blocked)");
-  await assert(!frontierIds.includes("esc#14"), "esc#14 excluded (human-gated)");
-  await assert(frontier.length === 4, `Frontier has 4 items (got ${frontier.length})`);
+  assert(frontierIds.includes("esc#11"), "esc#11 on frontier (dep met)");
+  assert(frontierIds.includes("esc#13"), "esc#13 on frontier (no deps)");
+  assert(frontierIds.includes("esc#15"), "esc#15 on frontier (capability, no deps)");
+  assert(frontierIds.includes("other#1"), "other#1 on frontier (different repo, no deps)");
+  assert(!frontierIds.includes("esc#10"), "esc#10 excluded (done)");
+  assert(!frontierIds.includes("esc#12"), "esc#12 excluded (blocked)");
+  assert(!frontierIds.includes("esc#14"), "esc#14 excluded (human-gated)");
+  assert(frontier.length === 4, `Frontier has 4 items (got ${frontier.length})`);
 
   // ─── 2. queryOverlaps ─────────────────────────────────────────────
   console.log("\n2. queryOverlaps");
-  const overlaps = await queryOverlaps(db);
+  const overlaps = queryOverlaps(db);
 
   // esc#11 & esc#13 share shared/utils.ts (same repo)
   // esc#11 & other#1 share shared/utils.ts (cross-repo)
   // esc#13 & other#1 share shared/utils.ts (cross-repo)
-  await assert(overlaps.length === 3, `Found 3 overlap pairs (got ${overlaps.length})`);
+  assert(overlaps.length === 3, `Found 3 overlap pairs (got ${overlaps.length})`);
 
   const escPair = overlaps.find((p) => {
     const ids = [p.node_a, p.node_b].sort();
     return ids[0] === "esc#11" && ids[1] === "esc#13";
   });
-  await assert(escPair !== undefined, "esc#11 + esc#13 overlap pair found");
-  await assert(
+  assert(escPair !== undefined, "esc#11 + esc#13 overlap pair found");
+  assert(
     escPair!.shared_files.includes("shared/utils.ts"),
     `Shared file is shared/utils.ts`
   );
 
   // ─── 3. queryBlocked ──────────────────────────────────────────────
   console.log("\n3. queryBlocked");
-  const blocked = await queryBlocked(db);
+  const blocked = queryBlocked(db);
 
-  await assert(blocked.length === 1, `1 blocked item (got ${blocked.length})`);
-  await assert(blocked[0].id === "esc#12", "esc#12 is blocked");
-  await assert(blocked[0].blockers.length === 1, "esc#12 has 1 blocker");
-  await assert(blocked[0].blockers[0].id === "esc#13", "esc#12 blocked by esc#13");
+  assert(blocked.length === 1, `1 blocked item (got ${blocked.length})`);
+  assert(blocked[0].id === "esc#12", "esc#12 is blocked");
+  assert(blocked[0].blockers.length === 1, "esc#12 has 1 blocker");
+  assert(blocked[0].blockers[0].id === "esc#13", "esc#12 blocked by esc#13");
 
   // ─── 4. queryHumanGated ───────────────────────────────────────────
   console.log("\n4. queryHumanGated");
-  const humanGated = await queryHumanGated(db);
+  const humanGated = queryHumanGated(db);
 
-  await assert(humanGated.length === 1, `1 human-gated item (got ${humanGated.length})`);
-  await assert(humanGated[0].id === "esc#14", "esc#14 is human-gated");
+  assert(humanGated.length === 1, `1 human-gated item (got ${humanGated.length})`);
+  assert(humanGated[0].id === "esc#14", "esc#14 is human-gated");
 
   // ─── 5. buildParallelGroups (no assessments = conservative) ───────
   console.log("\n5. buildParallelGroups (default/conservative)");
@@ -192,8 +191,8 @@ async function run() {
   // Items from different repos should be in separate groups
   const escapementGroups = groups.filter((g) => g.repo === "fusupo/escapement");
   const otherGroups = groups.filter((g) => g.repo === "fusupo/other-repo");
-  await assert(otherGroups.length === 1, "other-repo has 1 group");
-  await assert(otherGroups[0].nodes.length === 1, "other-repo group has 1 node");
+  assert(otherGroups.length === 1, "other-repo has 1 group");
+  assert(otherGroups[0].nodes.length === 1, "other-repo group has 1 node");
 
   // Without assessments, esc#11 and esc#13 overlap on shared/utils.ts
   // which defaults to 'unknown' -- they should be in separate groups
@@ -203,18 +202,18 @@ async function run() {
   const group13 = escapementGroups.find((g) =>
     g.nodes.some((n) => n.id === "esc#13")
   );
-  await assert(group11 !== undefined, "esc#11 assigned to a group");
-  await assert(group13 !== undefined, "esc#13 assigned to a group");
+  assert(group11 !== undefined, "esc#11 assigned to a group");
+  assert(group13 !== undefined, "esc#13 assigned to a group");
 
   // They should NOT be in the same group (unknown overlap)
   const sameGroup = group11 === group13;
-  await assert(!sameGroup, "esc#11 and esc#13 in SEPARATE groups (unknown overlap)");
+  assert(!sameGroup, "esc#11 and esc#13 in SEPARATE groups (unknown overlap)");
 
   // esc#15 has no files, should be in any group without conflict
   const group15 = escapementGroups.find((g) =>
     g.nodes.some((n) => n.id === "esc#15")
   );
-  await assert(group15 !== undefined, "esc#15 assigned to a group");
+  assert(group15 !== undefined, "esc#15 assigned to a group");
 
   // ─── 6. buildParallelGroups (with trivial assessment) ─────────────
   console.log("\n6. buildParallelGroups (trivial assessment)");
@@ -235,7 +234,7 @@ async function run() {
     g.nodes.some((n) => n.id === "esc#13")
   );
   const trivialSameGroup = trivialGroup11 === trivialGroup13;
-  await assert(trivialSameGroup, "esc#11 and esc#13 in SAME group (trivial overlap)");
+  assert(trivialSameGroup, "esc#11 and esc#13 in SAME group (trivial overlap)");
 
   // ─── 7. buildParallelGroups (semantic assessment) ─────────────────
   console.log("\n7. buildParallelGroups (semantic assessment)");
@@ -254,13 +253,13 @@ async function run() {
     g.nodes.some((n) => n.id === "esc#13")
   );
   const semSameGroup = semGroup11 === semGroup13;
-  await assert(!semSameGroup, "esc#11 and esc#13 in SEPARATE groups (semantic overlap)");
+  assert(!semSameGroup, "esc#11 and esc#13 in SEPARATE groups (semantic overlap)");
 
   // ─── 8. overlapKey canonical ordering ─────────────────────────────
   console.log("\n8. overlapKey");
   const key1 = overlapKey("esc#11", "esc#13", "shared/utils.ts");
   const key2 = overlapKey("esc#13", "esc#11", "shared/utils.ts");
-  await assert(key1 === key2, "overlapKey is order-independent");
+  assert(key1 === key2, "overlapKey is order-independent");
 
   // ─── 9. computeOwnedFiles ─────────────────────────────────────────
   console.log("\n9. computeOwnedFiles");
@@ -269,11 +268,11 @@ async function run() {
     ["manifest/queries/frontier.sql", "shared/utils.ts"],
     overlapMap.get("esc#11")
   );
-  await assert(
+  assert(
     owned11.includes("manifest/queries/frontier.sql"),
     "frontier.sql is owned by esc#11"
   );
-  await assert(
+  assert(
     !owned11.includes("shared/utils.ts"),
     "shared/utils.ts is NOT owned (shared)"
   );
@@ -282,11 +281,11 @@ async function run() {
   console.log("\n10. computeForbiddenFiles");
   const escFrontier = frontier.filter((f) => f.repo === "fusupo/escapement");
   const forbidden11 = computeForbiddenFiles("esc#11", escFrontier, overlapMap);
-  await assert(
+  assert(
     forbidden11.includes("src/components/Dashboard.tsx"),
     "Dashboard.tsx is forbidden for esc#11"
   );
-  await assert(
+  assert(
     !forbidden11.includes("shared/utils.ts"),
     "shared/utils.ts NOT forbidden (it's shared, not owned by other)"
   );
@@ -302,7 +301,7 @@ async function run() {
     n.files_shared.some((sf) => sf.assessment === "additive")
   );
   if (!hasAdditive) {
-    await assert(noOrder === undefined, "No merge order when no additive files");
+    assert(noOrder === undefined, "No merge order when no additive files");
   }
 
   // Create a mock group with additive files
@@ -333,8 +332,8 @@ async function run() {
     ],
   };
   const additiveOrder = determineMergeOrder(mockAdditiveGroup);
-  await assert(additiveOrder !== undefined, "Merge order exists for additive group");
-  await assert(
+  assert(additiveOrder !== undefined, "Merge order exists for additive group");
+  assert(
     additiveOrder![0] === "b",
     "Item with fewer additive files merges first"
   );
@@ -342,65 +341,64 @@ async function run() {
   // ─── 12. buildValidationPolicy ─────────────────────────────────────
   console.log("\n12. buildValidationPolicy");
   const policy = buildValidationPolicy(groups);
-  await assert(
+  assert(
     policy.max_concurrent_node_heavy_tasks >= 1,
     `max_concurrent >= 1 (got ${policy.max_concurrent_node_heavy_tasks})`
   );
-  await assert(
+  assert(
     policy.serialized_checks.includes("typescript-build"),
     "typescript-build is serialized"
   );
 
   // ─── 13. buildDispatchPlan (full assembly) ─────────────────────────
   console.log("\n13. buildDispatchPlan");
-  const plan = await buildDispatchPlan(db);
+  const plan = buildDispatchPlan(db);
 
-  await assert(plan.generated_at.length > 0, "generated_at is set");
-  await assert(plan.summary.dispatchable_now === 4, `4 dispatchable (got ${plan.summary.dispatchable_now})`);
-  await assert(plan.summary.blocked_count === 1, `1 blocked (got ${plan.summary.blocked_count})`);
-  await assert(plan.summary.human_gate_count === 1, `1 human-gated (got ${plan.summary.human_gate_count})`);
-  await assert(plan.sequential.length === 1, `1 sequential node (got ${plan.sequential.length})`);
-  await assert(plan.sequential[0].id === "esc#12", "esc#12 is sequential");
-  await assert(
+  assert(plan.generated_at.length > 0, "generated_at is set");
+  assert(plan.summary.dispatchable_now === 4, `4 dispatchable (got ${plan.summary.dispatchable_now})`);
+  assert(plan.summary.blocked_count === 1, `1 blocked (got ${plan.summary.blocked_count})`);
+  assert(plan.summary.human_gate_count === 1, `1 human-gated (got ${plan.summary.human_gate_count})`);
+  assert(plan.sequential.length === 1, `1 sequential node (got ${plan.sequential.length})`);
+  assert(plan.sequential[0].id === "esc#12", "esc#12 is sequential");
+  assert(
     plan.sequential[0].blocked_by.includes("esc#13"),
     "esc#12 blocked by esc#13"
   );
-  await assert(plan.parallel_groups.length > 0, "Has parallel groups");
-  await assert(plan.assumptions.length > 0, "Has assumptions");
+  assert(plan.parallel_groups.length > 0, "Has parallel groups");
+  assert(plan.assumptions.length > 0, "Has assumptions");
 
   // ─── 14. formatPlan ────────────────────────────────────────────────
   console.log("\n14. formatPlan");
   const output = formatPlan(plan);
-  await assert(output.includes("Dispatch Plan"), "Output contains title");
-  await assert(output.includes("Parallel Group"), "Output contains parallel groups");
-  await assert(output.includes("Sequential"), "Output contains sequential section");
-  await assert(output.includes("Validation Policy"), "Output contains validation policy");
-  await assert(output.includes("esc#12"), "Output mentions blocked item");
+  assert(output.includes("Dispatch Plan"), "Output contains title");
+  assert(output.includes("Parallel Group"), "Output contains parallel groups");
+  assert(output.includes("Sequential"), "Output contains sequential section");
+  assert(output.includes("Validation Policy"), "Output contains validation policy");
+  assert(output.includes("esc#12"), "Output mentions blocked item");
 
   // ─── 15. Multi-repo partitioning ───────────────────────────────────
   console.log("\n15. Multi-repo partitioning");
   const repoSet = new Set(plan.parallel_groups.map((g) => g.repo));
-  await assert(repoSet.has("fusupo/escapement"), "Has escapement groups");
-  await assert(repoSet.has("fusupo/other-repo"), "Has other-repo group");
+  assert(repoSet.has("fusupo/escapement"), "Has escapement groups");
+  assert(repoSet.has("fusupo/other-repo"), "Has other-repo group");
 
-  // other#1 shares shared/utils.ts with esc#11 and esc#13 in the overlap query,
-  // but since they're in different repos, the grouping logic places them
-  // in separate groups partitioned by repo
   const otherPlanGroup = plan.parallel_groups.find(
     (g) => g.repo === "fusupo/other-repo"
   );
-  await assert(otherPlanGroup !== undefined, "other-repo has its own group");
-  await assert(
+  assert(otherPlanGroup !== undefined, "other-repo has its own group");
+  assert(
     otherPlanGroup!.nodes.length === 1,
     "other-repo group has 1 node"
   );
 
   // ─── Done ──────────────────────────────────────────────────────────
   console.log("\n\u2705 All plan tests passed!\n");
-  await db.close();
+  db.close();
 }
 
-run().catch((e) => {
+try {
+  run();
+} catch (e: any) {
   console.error("\n\u274c Test failed:", e.message);
   process.exit(1);
-});
+}

--- a/manifest/test-queries.ts
+++ b/manifest/test-queries.ts
@@ -1,4 +1,4 @@
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { applySchema } from "./init.ts";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
@@ -10,9 +10,15 @@ function loadQuery(name: string): string {
   return readFileSync(resolve(__dirname, "queries", `${name}.sql`), "utf-8");
 }
 
-async function assert(condition: boolean, msg: string) {
+function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(`FAIL: ${msg}`);
   console.log(`  \u2713 ${msg}`);
+}
+
+function parseJsonArray(v: unknown): string[] {
+  if (typeof v === "string") return JSON.parse(v);
+  if (Array.isArray(v)) return v;
+  return [];
 }
 
 /**
@@ -30,8 +36,8 @@ async function assert(condition: boolean, msg: string) {
  *   esc#11 and esc#13 share predicted files (overlap pair)
  *   esc#15  (planned, capability, no deps, no files -- dispatchable but no overlap)
  */
-async function seed(db: PGlite) {
-  await db.exec(`
+function seed(db: Database.Database) {
+  db.exec(`
     INSERT INTO work_items (id, name, kind, state) VALUES
       ('phase:alpha', 'Phase Alpha', 'phase', 'planned'),
       ('track:alpha:core', 'Core Track', 'track', 'planned'),
@@ -47,53 +53,53 @@ async function seed(db: PGlite) {
         'https://github.com/fusupo/escapement/issues/10',
         '10-schema-setup',
         '../escapement-ctx/10-schema-setup/archive',
-        ARRAY['manifest/schema.sql', 'manifest/init.ts'],
-        ARRAY['manifest/schema.sql', 'manifest/init.ts'],
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["manifest/schema.sql", "manifest/init.ts"]',
+        '["manifest/schema.sql", "manifest/init.ts"]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'esc#11', 'Core queries', 'issue', 'planned',
         'escapement', 11,
         'https://github.com/fusupo/escapement/issues/11',
         NULL, NULL,
-        ARRAY['manifest/queries/frontier.sql', 'manifest/queries/overlap.sql', 'shared/utils.ts'],
-        '{}',
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["manifest/queries/frontier.sql", "manifest/queries/overlap.sql", "shared/utils.ts"]',
+        '[]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'esc#12', 'Bootstrap CLI', 'issue', 'planned',
         'escapement', 12,
         'https://github.com/fusupo/escapement/issues/12',
         NULL, NULL,
-        ARRAY['manifest/bootstrap.ts'],
-        '{}',
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["manifest/bootstrap.ts"]',
+        '[]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'esc#13', 'UI components', 'issue', 'planned',
         'escapement', 13,
         'https://github.com/fusupo/escapement/issues/13',
         NULL, NULL,
-        ARRAY['src/components/Dashboard.tsx', 'shared/utils.ts'],
-        '{}',
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '["src/components/Dashboard.tsx", "shared/utils.ts"]',
+        '[]',
+        '{"bootstrap_status":"active","needs_human":false}'
       ),
       (
         'esc#14', 'Design review', 'issue', 'planned',
         'escapement', 14,
         'https://github.com/fusupo/escapement/issues/14',
         NULL, NULL,
-        ARRAY['docs/design.md'],
-        '{}',
-        '{"bootstrap_status":"active","needs_human":true}'::jsonb
+        '["docs/design.md"]',
+        '[]',
+        '{"bootstrap_status":"active","needs_human":true}'
       ),
       (
         'esc#15', 'Deprecate construct', 'capability', 'planned',
         'escapement', NULL, NULL,
         NULL, NULL,
-        '{}',
-        '{}',
-        '{"bootstrap_status":"active","needs_human":false}'::jsonb
+        '[]',
+        '[]',
+        '{"bootstrap_status":"active","needs_human":false}'
       );
 
     INSERT INTO edges (from_id, rel, to_id, confidence) VALUES
@@ -109,65 +115,67 @@ async function seed(db: PGlite) {
   `);
 }
 
-async function run() {
+function run() {
   console.log("Manifest query tests\n");
 
-  // Setup: in-memory PGlite with schema and seed data
+  // Setup: in-memory SQLite with schema and seed data
   console.log("0. Setup");
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
-  await seed(db);
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
+  seed(db);
   console.log("  \u2713 Schema applied and data seeded\n");
 
   // ─── 1. Frontier Query ───────────────────────────────────────────
   console.log("1. Frontier query (frontier.sql)");
   const frontierSql = loadQuery("frontier");
-  const frontier = await db.query<{
+  const frontier = db.prepare(frontierSql).all() as {
     id: string; name: string; kind: string;
     repo: string | null; scope_hint: string | null;
-    predicted_files: string[];
-  }>(frontierSql);
+    predicted_files: string;
+  }[];
 
-  const frontierIds = frontier.rows.map((r) => r.id).sort();
+  const frontierIds = frontier.map((r) => r.id).sort();
 
   // esc#11: planned, depends_on esc#10 (done) -> dispatchable
-  await assert(frontierIds.includes("esc#11"), "esc#11 is on the frontier (dep met)");
+  assert(frontierIds.includes("esc#11"), "esc#11 is on the frontier (dep met)");
 
   // esc#13: planned, no deps -> dispatchable
-  await assert(frontierIds.includes("esc#13"), "esc#13 is on the frontier (no deps)");
+  assert(frontierIds.includes("esc#13"), "esc#13 is on the frontier (no deps)");
 
   // esc#15: planned capability, no deps -> dispatchable
-  await assert(frontierIds.includes("esc#15"), "esc#15 capability is on the frontier");
+  assert(frontierIds.includes("esc#15"), "esc#15 capability is on the frontier");
 
   // esc#10: done -> not on frontier
-  await assert(!frontierIds.includes("esc#10"), "esc#10 excluded (done)");
+  assert(!frontierIds.includes("esc#10"), "esc#10 excluded (done)");
 
   // esc#12: depends_on esc#13 (planned, not done) -> blocked
-  await assert(!frontierIds.includes("esc#12"), "esc#12 excluded (unmet dep on esc#13)");
+  assert(!frontierIds.includes("esc#12"), "esc#12 excluded (unmet dep on esc#13)");
 
   // esc#14: needs_human=true -> not dispatchable
-  await assert(!frontierIds.includes("esc#14"), "esc#14 excluded (needs_human gate)");
+  assert(!frontierIds.includes("esc#14"), "esc#14 excluded (needs_human gate)");
 
-  await assert(frontierIds.length === 3, `Frontier has 3 items (got ${frontierIds.length})`);
+  assert(frontierIds.length === 3, `Frontier has 3 items (got ${frontierIds.length})`);
 
   // ─── 2. Overlap Query ────────────────────────────────────────────
   console.log("\n2. Overlap query (overlap.sql)");
   const overlapSql = loadQuery("overlap");
-  const overlap = await db.query<{
-    node_a: string; node_b: string; shared_files: string[];
-  }>(overlapSql);
+  const overlap = db.prepare(overlapSql).all() as {
+    node_a: string; node_b: string; shared_files: string;
+  }[];
 
-  await assert(overlap.rows.length === 1, `Found 1 overlap pair (got ${overlap.rows.length})`);
+  assert(overlap.length === 1, `Found 1 overlap pair (got ${overlap.length})`);
 
-  const pair = overlap.rows[0];
+  const pair = overlap[0];
   const pairIds = [pair.node_a, pair.node_b].sort();
-  await assert(
+  assert(
     pairIds[0] === "esc#11" && pairIds[1] === "esc#13",
     `Overlap pair is esc#11 + esc#13 (got ${pairIds.join(" + ")})`
   );
-  await assert(
-    pair.shared_files.length === 1 && pair.shared_files[0] === "shared/utils.ts",
-    `Shared file is shared/utils.ts (got ${JSON.stringify(pair.shared_files)})`
+  const sharedFiles = parseJsonArray(pair.shared_files);
+  assert(
+    sharedFiles.length === 1 && sharedFiles[0] === "shared/utils.ts",
+    `Shared file is shared/utils.ts (got ${JSON.stringify(sharedFiles)})`
   );
 
   // ─── 3. Dependencies Query ───────────────────────────────────────
@@ -175,82 +183,78 @@ async function run() {
   const depsSql = loadQuery("dependencies");
 
   // esc#11 depends_on esc#10
-  const deps11 = await db.query<{ id: string; name: string; state: string }>(
-    depsSql, ["esc#11"]
-  );
-  await assert(deps11.rows.length === 1, "esc#11 has 1 dependency");
-  await assert(deps11.rows[0].id === "esc#10", "esc#11 depends on esc#10");
-  await assert(deps11.rows[0].state === "done", "esc#10 state is done");
+  const deps11 = db.prepare(depsSql).all("esc#11") as { id: string; name: string; state: string }[];
+  assert(deps11.length === 1, "esc#11 has 1 dependency");
+  assert(deps11[0].id === "esc#10", "esc#11 depends on esc#10");
+  assert(deps11[0].state === "done", "esc#10 state is done");
 
   // esc#12 depends_on esc#13
-  const deps12 = await db.query<{ id: string; name: string; state: string }>(
-    depsSql, ["esc#12"]
-  );
-  await assert(deps12.rows.length === 1, "esc#12 has 1 dependency");
-  await assert(deps12.rows[0].id === "esc#13", "esc#12 depends on esc#13");
-  await assert(deps12.rows[0].state === "planned", "esc#13 state is planned (blocking)");
+  const deps12 = db.prepare(depsSql).all("esc#12") as { id: string; name: string; state: string }[];
+  assert(deps12.length === 1, "esc#12 has 1 dependency");
+  assert(deps12[0].id === "esc#13", "esc#12 depends on esc#13");
+  assert(deps12[0].state === "planned", "esc#13 state is planned (blocking)");
 
   // esc#13 has no deps
-  const deps13 = await db.query<{ id: string; name: string; state: string }>(
-    depsSql, ["esc#13"]
-  );
-  await assert(deps13.rows.length === 0, "esc#13 has no dependencies");
+  const deps13 = db.prepare(depsSql).all("esc#13") as { id: string; name: string; state: string }[];
+  assert(deps13.length === 0, "esc#13 has no dependencies");
 
   // ─── 4. Progress Query ───────────────────────────────────────────
   console.log("\n4. Progress query (progress.sql)");
   const progressSql = loadQuery("progress");
-  const progress = await db.query<{
-    name: string; total_items: string; done_items: string;
-  }>(progressSql);
+  const progress = db.prepare(progressSql).all() as {
+    name: string; total_items: number; done_items: number;
+  }[];
 
   // Build a lookup by name
-  const byName = new Map(progress.rows.map((r) => [r.name, r]));
+  const byName = new Map(progress.map((r) => [r.name, r]));
 
   // Core Track: esc#10 (done), esc#11 (planned), esc#12 (planned) -> 3 total, 1 done
   const core = byName.get("Core Track");
-  await assert(core !== undefined, "Core Track appears in progress");
-  await assert(Number(core!.total_items) === 3, `Core Track total=3 (got ${core!.total_items})`);
-  await assert(Number(core!.done_items) === 1, `Core Track done=1 (got ${core!.done_items})`);
+  assert(core !== undefined, "Core Track appears in progress");
+  assert(core!.total_items === 3, `Core Track total=3 (got ${core!.total_items})`);
+  assert(core!.done_items === 1, `Core Track done=1 (got ${core!.done_items})`);
 
   // UI Track: esc#13 (planned), esc#14 (planned) -> 2 total, 0 done
   const ui = byName.get("UI Track");
-  await assert(ui !== undefined, "UI Track appears in progress");
-  await assert(Number(ui!.total_items) === 2, `UI Track total=2 (got ${ui!.total_items})`);
-  await assert(Number(ui!.done_items) === 0, `UI Track done=0 (got ${ui!.done_items})`);
+  assert(ui !== undefined, "UI Track appears in progress");
+  assert(ui!.total_items === 2, `UI Track total=2 (got ${ui!.total_items})`);
+  assert(ui!.done_items === 0, `UI Track done=0 (got ${ui!.done_items})`);
 
   // Phase Alpha: all 5 issues (recursive through tracks) -> 5 total, 1 done
   const phase = byName.get("Phase Alpha");
-  await assert(phase !== undefined, "Phase Alpha appears in progress");
-  await assert(Number(phase!.total_items) === 5, `Phase Alpha total=5 (got ${phase!.total_items})`);
-  await assert(Number(phase!.done_items) === 1, `Phase Alpha done=1 (got ${phase!.done_items})`);
+  assert(phase !== undefined, "Phase Alpha appears in progress");
+  assert(phase!.total_items === 5, `Phase Alpha total=5 (got ${phase!.total_items})`);
+  assert(phase!.done_items === 1, `Phase Alpha done=1 (got ${phase!.done_items})`);
 
   // ─── 5. Provenance Query ─────────────────────────────────────────
   console.log("\n5. Provenance query (provenance.sql)");
   const provSql = loadQuery("provenance");
 
   // esc#10 is done with archive_path set
-  const prov10 = await db.query<{
+  const prov10 = db.prepare(provSql).all("esc#10") as {
     id: string; name: string; branch: string; archive_path: string;
-  }>(provSql, ["esc#10"]);
-  await assert(prov10.rows.length === 1, "esc#10 has provenance");
-  await assert(
-    prov10.rows[0].archive_path === "../escapement-ctx/10-schema-setup/archive",
-    `Correct archive path (got ${prov10.rows[0].archive_path})`
+  }[];
+  assert(prov10.length === 1, "esc#10 has provenance");
+  assert(
+    prov10[0].archive_path === "../escapement-ctx/10-schema-setup/archive",
+    `Correct archive path (got ${prov10[0].archive_path})`
   );
-  await assert(prov10.rows[0].branch === "10-schema-setup", "Correct branch");
+  assert(prov10[0].branch === "10-schema-setup", "Correct branch");
 
   // esc#11 has no archive_path (not done)
-  const prov11 = await db.query<{
+  const prov11 = db.prepare(provSql).all("esc#11") as {
     id: string; name: string; branch: string; archive_path: string;
-  }>(provSql, ["esc#11"]);
-  await assert(prov11.rows.length === 0, "esc#11 has no provenance (not archived)");
+  }[];
+  assert(prov11.length === 0, "esc#11 has no provenance (not archived)");
 
   // ─── Done ────────────────────────────────────────────────────────
   console.log("\n\u2705 All query tests passed!\n");
-  await db.close();
+  db.close();
 }
 
-run().catch((e) => {
+try {
+  run();
+} catch (e: any) {
   console.error("\n\u274c Test failed:", e.message);
   process.exit(1);
-});
+}

--- a/manifest/test-schema.ts
+++ b/manifest/test-schema.ts
@@ -1,41 +1,40 @@
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { applySchema } from "./init.ts";
 
-async function assert(condition: boolean, msg: string) {
+function assert(condition: boolean, msg: string) {
   if (!condition) throw new Error(`FAIL: ${msg}`);
-  console.log(`  ✓ ${msg}`);
+  console.log(`  \u2713 ${msg}`);
 }
 
-async function run() {
+function run() {
   console.log("Manifest schema smoke test\n");
 
-  // 1. Create in-memory PGlite and apply schema
+  // 1. Create in-memory SQLite and apply schema
   console.log("1. Schema application");
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
-  console.log("  ✓ Schema applied to fresh PGlite instance");
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
+  console.log("  \u2713 Schema applied to fresh SQLite instance");
 
   // 2. Verify tables exist
   console.log("\n2. Table verification");
-  const tables = await db.query<{ table_name: string }>(`
-    SELECT table_name FROM information_schema.tables
-    WHERE table_schema = 'public'
-    ORDER BY table_name
-  `);
-  const tableNames = tables.rows.map((r) => r.table_name);
-  await assert(tableNames.includes("work_items"), "work_items table exists");
-  await assert(tableNames.includes("edges"), "edges table exists");
+  const tables = db.prepare(
+    "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+  ).all() as { name: string }[];
+  const tableNames = tables.map((r) => r.name);
+  assert(tableNames.includes("work_items"), "work_items table exists");
+  assert(tableNames.includes("edges"), "edges table exists");
 
   // 3. Insert a phase work item
   console.log("\n3. Insert work items");
-  await db.exec(`
+  db.exec(`
     INSERT INTO work_items (id, name, kind, state) VALUES
       ('phase:test', 'Test Phase', 'phase', 'planned')
   `);
-  await assert(true, "Inserted phase work item");
+  assert(true, "Inserted phase work item");
 
   // 4. Insert an issue work item with predicted_files
-  await db.exec(`
+  db.exec(`
     INSERT INTO work_items (
       id, name, kind, state, repo, issue_number, issue_url, predicted_files, meta
     ) VALUES (
@@ -46,128 +45,129 @@ async function run() {
       'systema-relica',
       100,
       'https://github.com/example/repo/issues/100',
-      ARRAY['src/foo.ts', 'src/bar.ts'],
-      '{"bootstrap_status":"active","needs_human":false}'::jsonb
+      '["src/foo.ts", "src/bar.ts"]',
+      '{"bootstrap_status":"active","needs_human":false}'
     )
   `);
-  await assert(true, "Inserted issue work item with predicted_files");
+  assert(true, "Inserted issue work item with predicted_files");
 
   // 5. Insert edges
   console.log("\n4. Insert edges");
-  await db.exec(`
+  db.exec(`
     INSERT INTO edges (from_id, rel, to_id, confidence) VALUES
       ('sr#100', 'is_part_of', 'phase:test', 'certain')
   `);
-  await assert(true, "Inserted is_part_of edge");
+  assert(true, "Inserted is_part_of edge");
 
   // 6. Query back and verify
   console.log("\n5. Query verification");
-  const items = await db.query<{ id: string; name: string; kind: string }>(
-    `SELECT id, name, kind FROM work_items ORDER BY id`
-  );
-  await assert(items.rows.length === 2, `Got ${items.rows.length} work items (expected 2)`);
+  const items = db.prepare(
+    "SELECT id, name, kind FROM work_items ORDER BY id"
+  ).all() as { id: string; name: string; kind: string }[];
+  assert(items.length === 2, `Got ${items.length} work items (expected 2)`);
 
-  const edges = await db.query<{ from_id: string; rel: string; to_id: string }>(
-    `SELECT from_id, rel, to_id FROM edges`
-  );
-  await assert(edges.rows.length === 1, `Got ${edges.rows.length} edge (expected 1)`);
-  await assert(edges.rows[0].rel === "is_part_of", "Edge rel is 'is_part_of'");
+  const edges = db.prepare(
+    "SELECT from_id, rel, to_id FROM edges"
+  ).all() as { from_id: string; rel: string; to_id: string }[];
+  assert(edges.length === 1, `Got ${edges.length} edge (expected 1)`);
+  assert(edges[0].rel === "is_part_of", "Edge rel is 'is_part_of'");
 
-  // 7. Verify predicted_files array and GIN index work
-  console.log("\n6. Array + GIN index verification");
-  const overlap = await db.query<{ id: string }>(
-    `SELECT id FROM work_items WHERE predicted_files && ARRAY['src/foo.ts']`
-  );
-  await assert(overlap.rows.length === 1, "GIN index array overlap query works");
-  await assert(overlap.rows[0].id === "sr#100", "Correct item found via array overlap");
+  // 7. Verify predicted_files array query using json_each
+  console.log("\n6. JSON array query verification");
+  const overlap = db.prepare(
+    `SELECT id FROM work_items WHERE EXISTS (
+       SELECT 1 FROM json_each(predicted_files) WHERE value = 'src/foo.ts'
+     )`
+  ).all() as { id: string }[];
+  assert(overlap.length === 1, "json_each array query works");
+  assert(overlap[0].id === "sr#100", "Correct item found via json_each query");
 
   // 8. Test UNIQUE constraint on edges
   console.log("\n7. Constraint tests");
   try {
-    await db.exec(`
+    db.exec(`
       INSERT INTO edges (from_id, rel, to_id, confidence) VALUES
         ('sr#100', 'is_part_of', 'phase:test', 'certain')
     `);
     throw new Error("FAIL: Duplicate edge should have been rejected");
   } catch (e: any) {
-    await assert(
-      e.message.includes("unique") || e.message.includes("duplicate"),
+    assert(
+      e.message.includes("UNIQUE") || e.message.includes("unique"),
       "UNIQUE constraint rejects duplicate edge"
     );
   }
 
   // 9. Test CHECK constraint on kind
   try {
-    await db.exec(`
+    db.exec(`
       INSERT INTO work_items (id, name, kind) VALUES
         ('bad#1', 'Bad item', 'invalid_kind')
     `);
     throw new Error("FAIL: Invalid kind should have been rejected");
   } catch (e: any) {
-    await assert(
-      e.message.includes("check") || e.message.includes("violates"),
+    assert(
+      e.message.includes("CHECK") || e.message.includes("constraint"),
       "CHECK constraint rejects invalid kind"
     );
   }
 
   // 10. Test CHECK constraint on state
   try {
-    await db.exec(`
+    db.exec(`
       INSERT INTO work_items (id, name, kind, state) VALUES
         ('bad#2', 'Bad state', 'issue', 'invalid_state')
     `);
     throw new Error("FAIL: Invalid state should have been rejected");
   } catch (e: any) {
-    await assert(
-      e.message.includes("check") || e.message.includes("violates"),
+    assert(
+      e.message.includes("CHECK") || e.message.includes("constraint"),
       "CHECK constraint rejects invalid state"
     );
   }
 
   // 11. Test CHECK constraint on edge rel
   try {
-    await db.exec(`
+    db.exec(`
       INSERT INTO edges (from_id, rel, to_id) VALUES
         ('sr#100', 'invalid_rel', 'phase:test')
     `);
     throw new Error("FAIL: Invalid rel should have been rejected");
   } catch (e: any) {
-    await assert(
-      e.message.includes("check") || e.message.includes("violates"),
+    assert(
+      e.message.includes("CHECK") || e.message.includes("constraint"),
       "CHECK constraint rejects invalid edge rel"
     );
   }
 
   // 12. Test FK constraint
   try {
-    await db.exec(`
+    db.exec(`
       INSERT INTO edges (from_id, rel, to_id) VALUES
         ('nonexistent', 'depends_on', 'phase:test')
     `);
     throw new Error("FAIL: FK violation should have been rejected");
   } catch (e: any) {
-    await assert(
-      e.message.includes("foreign key") || e.message.includes("violates"),
+    assert(
+      e.message.includes("FOREIGN KEY") || e.message.includes("foreign"),
       "FK constraint rejects nonexistent from_id"
     );
   }
 
   // 13. Test defaults
   console.log("\n8. Default value tests");
-  const defaults = await db.query<{ state: string; meta: any }>(
-    `SELECT state, meta FROM work_items WHERE id = 'phase:test'`
-  );
-  await assert(defaults.rows[0].state === "planned", "Default state is 'planned'");
-  await assert(
-    JSON.stringify(defaults.rows[0].meta) === "{}",
-    "Default meta is empty object"
-  );
+  const defaults = db.prepare(
+    "SELECT state, meta FROM work_items WHERE id = 'phase:test'"
+  ).get() as { state: string; meta: string };
+  assert(defaults.state === "planned", "Default state is 'planned'");
+  assert(defaults.meta === "{}", "Default meta is empty object");
 
-  console.log("\n✅ All tests passed!\n");
-  await db.close();
+  console.log("\n\u2705 All tests passed!\n");
+  db.close();
 }
 
-run().catch((e) => {
-  console.error("\n❌ Test failed:", e.message);
+try {
+  run();
+} catch (e: any) {
+  console.error("\n\u274c Test failed:", e.message);
   process.exit(1);
-});
+}

--- a/manifest/test-seed.ts
+++ b/manifest/test-seed.ts
@@ -9,7 +9,7 @@
  * 5. Idempotency: running seed twice does not duplicate data
  */
 
-import { PGlite } from "@electric-sql/pglite";
+import Database from "better-sqlite3";
 import { applySchema } from "./init.ts";
 import { seed } from "./seed.ts";
 
@@ -26,11 +26,17 @@ function assert(condition: boolean, msg: string) {
   }
 }
 
+function parseJsonArray(v: unknown): string[] {
+  if (typeof v === "string") return JSON.parse(v);
+  if (Array.isArray(v)) return v;
+  return [];
+}
+
 /**
  * Frontier query: planned issues whose dependencies are all done.
  */
-async function queryFrontier(db: PGlite): Promise<string[]> {
-  const result = await db.query<{ id: string }>(`
+function queryFrontier(db: Database.Database): string[] {
+  const result = db.prepare(`
     SELECT wi.id
     FROM work_items wi
     WHERE wi.state = 'planned'
@@ -43,60 +49,61 @@ async function queryFrontier(db: PGlite): Promise<string[]> {
           AND dep.state != 'done'
       )
     ORDER BY wi.id
-  `);
-  return result.rows.map((r) => r.id);
+  `).all() as { id: string }[];
+  return result.map((r) => r.id);
 }
 
-async function run() {
+function run() {
   console.log("Manifest seed tests\n");
 
-  // Setup: in-memory PGlite with schema
-  const db = await PGlite.create("memory://");
-  await applySchema(db);
+  // Setup: in-memory SQLite with schema
+  const db = new Database(":memory:");
+  db.pragma("foreign_keys = ON");
+  applySchema(db);
 
   // -----------------------------------------------------------------------
   // 1. Run seed and verify counts
   // -----------------------------------------------------------------------
   console.log("1. Seed execution and item counts");
-  const result = await seed(db);
+  const result = seed(db);
   assert(result.itemsInserted === 13, `Inserted ${result.itemsInserted} items (expected 13: 1 phase + 3 tracks + 9 issues)`);
   assert(result.edgesInserted === 22, `Inserted ${result.edgesInserted} edges (expected 22: 10 deps + 12 hierarchy)`);
 
   // Verify total counts from DB
-  const itemCount = await db.query<{ count: string }>(`SELECT count(*) AS count FROM work_items`);
-  assert(parseInt(itemCount.rows[0].count) === 13, `DB has 13 work items`);
+  const itemCount = db.prepare("SELECT count(*) AS count FROM work_items").get() as { count: number };
+  assert(itemCount.count === 13, `DB has 13 work items`);
 
-  const edgeCount = await db.query<{ count: string }>(`SELECT count(*) AS count FROM edges`);
-  assert(parseInt(edgeCount.rows[0].count) === 22, `DB has 22 edges`);
+  const edgeCount = db.prepare("SELECT count(*) AS count FROM edges").get() as { count: number };
+  assert(edgeCount.count === 22, `DB has 22 edges`);
 
   // -----------------------------------------------------------------------
   // 2. Verify work item kinds
   // -----------------------------------------------------------------------
   console.log("\n2. Work item kinds");
-  const phases = await db.query<{ count: string }>(`SELECT count(*) AS count FROM work_items WHERE kind = 'phase'`);
-  assert(parseInt(phases.rows[0].count) === 1, `1 phase entity`);
+  const phases = db.prepare("SELECT count(*) AS count FROM work_items WHERE kind = 'phase'").get() as { count: number };
+  assert(phases.count === 1, `1 phase entity`);
 
-  const trackCount = await db.query<{ count: string }>(`SELECT count(*) AS count FROM work_items WHERE kind = 'track'`);
-  assert(parseInt(trackCount.rows[0].count) === 3, `3 track entities`);
+  const trackCount = db.prepare("SELECT count(*) AS count FROM work_items WHERE kind = 'track'").get() as { count: number };
+  assert(trackCount.count === 3, `3 track entities`);
 
-  const issueCount = await db.query<{ count: string }>(`SELECT count(*) AS count FROM work_items WHERE kind = 'issue'`);
-  assert(parseInt(issueCount.rows[0].count) === 9, `9 issue entities`);
+  const issueCount = db.prepare("SELECT count(*) AS count FROM work_items WHERE kind = 'issue'").get() as { count: number };
+  assert(issueCount.count === 9, `9 issue entities`);
 
   // -----------------------------------------------------------------------
   // 3. Verify m#1 is done
   // -----------------------------------------------------------------------
   console.log("\n3. State verification");
-  const m1 = await db.query<{ state: string }>(`SELECT state FROM work_items WHERE id = 'm#1'`);
-  assert(m1.rows[0].state === "done", `m#1 state is 'done'`);
+  const m1 = db.prepare("SELECT state FROM work_items WHERE id = 'm#1'").get() as { state: string };
+  assert(m1.state === "done", `m#1 state is 'done'`);
 
-  const m4 = await db.query<{ state: string }>(`SELECT state FROM work_items WHERE id = 'm#4'`);
-  assert(m4.rows[0].state === "in_progress", `m#4 state is 'in_progress'`);
+  const m4 = db.prepare("SELECT state FROM work_items WHERE id = 'm#4'").get() as { state: string };
+  assert(m4.state === "in_progress", `m#4 state is 'in_progress'`);
 
   // -----------------------------------------------------------------------
   // 4. Frontier query: initial dispatchable set
   // -----------------------------------------------------------------------
   console.log("\n4. Frontier query (initial)");
-  const frontier1 = await queryFrontier(db);
+  const frontier1 = queryFrontier(db);
   assert(
     frontier1.length === 2,
     `Frontier has 2 items (expected: m#2, m#3 -- m#4 is in_progress so excluded)`
@@ -111,9 +118,9 @@ async function run() {
   // 5. Mark m#2 and m#3 done -> m#5 becomes dispatchable
   // -----------------------------------------------------------------------
   console.log("\n5. Unblocking behavior");
-  await db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#2', 'm#3')`);
+  db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#2', 'm#3')`);
 
-  const frontier2 = await queryFrontier(db);
+  const frontier2 = queryFrontier(db);
   assert(frontier2.includes("m#5"), `m#5 unblocked after m#2 and m#3 done`);
   assert(!frontier2.includes("m#6"), `m#6 still blocked (needs m#5)`);
   assert(!frontier2.includes("m#9"), `m#9 still blocked (needs m#6, m#7)`);
@@ -122,15 +129,15 @@ async function run() {
   // 6. Full chain: mark through to m#9
   // -----------------------------------------------------------------------
   console.log("\n6. Full dependency chain");
-  await db.exec(`UPDATE work_items SET state = 'done' WHERE id = 'm#5'`);
-  const frontier3 = await queryFrontier(db);
+  db.exec(`UPDATE work_items SET state = 'done' WHERE id = 'm#5'`);
+  const frontier3 = queryFrontier(db);
   assert(frontier3.includes("m#6"), `m#6 unblocked after m#5 done`);
   assert(frontier3.includes("m#7"), `m#7 unblocked after m#5 done`);
   assert(frontier3.includes("m#8"), `m#8 unblocked after m#5 done`);
   assert(!frontier3.includes("m#9"), `m#9 still blocked (needs m#6 and m#7)`);
 
-  await db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#6', 'm#7')`);
-  const frontier4 = await queryFrontier(db);
+  db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#6', 'm#7')`);
+  const frontier4 = queryFrontier(db);
   assert(frontier4.includes("m#9"), `m#9 unblocked after m#6 and m#7 done`);
   assert(frontier4.includes("m#8"), `m#8 still in frontier (independent)`);
 
@@ -138,19 +145,19 @@ async function run() {
   // 7. Hierarchy edges
   // -----------------------------------------------------------------------
   console.log("\n7. Hierarchy edges");
-  const trackToPhase = await db.query<{ count: string }>(`
+  const trackToPhase = db.prepare(`
     SELECT count(*) AS count FROM edges
     WHERE rel = 'is_part_of' AND to_id = 'phase:manifest'
     AND from_id LIKE 'track:%'
-  `);
-  assert(parseInt(trackToPhase.rows[0].count) === 3, `3 tracks belong to phase:manifest`);
+  `).get() as { count: number };
+  assert(trackToPhase.count === 3, `3 tracks belong to phase:manifest`);
 
-  const foundationItems = await db.query<{ from_id: string }>(`
+  const foundationItems = db.prepare(`
     SELECT from_id FROM edges
     WHERE rel = 'is_part_of' AND to_id = 'track:foundation'
     ORDER BY from_id
-  `);
-  const foundationIds = foundationItems.rows.map((r) => r.from_id);
+  `).all() as { from_id: string }[];
+  const foundationIds = foundationItems.map((r) => r.from_id);
   assert(
     foundationIds.length === 4 &&
       foundationIds.includes("m#1") &&
@@ -160,19 +167,19 @@ async function run() {
     `Foundation track has m#1-m#4`
   );
 
-  const planningItems = await db.query<{ from_id: string }>(`
+  const planningItems = db.prepare(`
     SELECT from_id FROM edges
     WHERE rel = 'is_part_of' AND to_id = 'track:planning'
     ORDER BY from_id
-  `);
-  assert(planningItems.rows.length === 4, `Planning track has 4 items (m#5-m#8)`);
+  `).all() as { from_id: string }[];
+  assert(planningItems.length === 4, `Planning track has 4 items (m#5-m#8)`);
 
-  const dispatchItems = await db.query<{ from_id: string }>(`
+  const dispatchItems = db.prepare(`
     SELECT from_id FROM edges
     WHERE rel = 'is_part_of' AND to_id = 'track:dispatch'
-  `);
+  `).all() as { from_id: string }[];
   assert(
-    dispatchItems.rows.length === 1 && dispatchItems.rows[0].from_id === "m#9",
+    dispatchItems.length === 1 && dispatchItems[0].from_id === "m#9",
     `Dispatch track has m#9`
   );
 
@@ -180,25 +187,25 @@ async function run() {
   // 8. Idempotency: running seed again should not duplicate
   // -----------------------------------------------------------------------
   console.log("\n8. Idempotency");
-  // Reset states for clean re-seed test
-  await db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#6', 'm#7', 'm#8')`);
-  const result2 = await seed(db);
+  db.exec(`UPDATE work_items SET state = 'done' WHERE id IN ('m#6', 'm#7', 'm#8')`);
+  const result2 = seed(db);
   assert(result2.itemsInserted === 0, `Re-seed inserted 0 items (idempotent)`);
   assert(result2.edgesInserted === 0, `Re-seed inserted 0 edges (idempotent)`);
 
-  const finalItemCount = await db.query<{ count: string }>(`SELECT count(*) AS count FROM work_items`);
-  assert(parseInt(finalItemCount.rows[0].count) === 13, `Still 13 items after re-seed`);
+  const finalItemCount = db.prepare("SELECT count(*) AS count FROM work_items").get() as { count: number };
+  assert(finalItemCount.count === 13, `Still 13 items after re-seed`);
 
   // -----------------------------------------------------------------------
   // 9. Predicted files populated
   // -----------------------------------------------------------------------
   console.log("\n9. Predicted files");
-  const m1files = await db.query<{ predicted_files: string[] }>(
-    `SELECT predicted_files FROM work_items WHERE id = 'm#1'`
-  );
-  assert(m1files.rows[0].predicted_files.length === 5, `m#1 has 5 predicted files`);
+  const m1files = db.prepare(
+    "SELECT predicted_files FROM work_items WHERE id = 'm#1'"
+  ).get() as { predicted_files: string };
+  const m1filesParsed = parseJsonArray(m1files.predicted_files);
+  assert(m1filesParsed.length === 5, `m#1 has 5 predicted files`);
   assert(
-    m1files.rows[0].predicted_files.includes("manifest/schema.sql"),
+    m1filesParsed.includes("manifest/schema.sql"),
     `m#1 predicted files include manifest/schema.sql`
   );
 
@@ -214,10 +221,12 @@ async function run() {
     console.log(`\nAll tests passed.`);
   }
 
-  await db.close();
+  db.close();
 }
 
-run().catch((e) => {
+try {
+  run();
+} catch (e: any) {
   console.error("\nTest crashed:", e.message);
   process.exit(1);
-});
+}

--- a/skills/manifest-bootstrap/SKILL.md
+++ b/skills/manifest-bootstrap/SKILL.md
@@ -19,7 +19,7 @@ tools:
 
 ## Purpose
 
-Build a manifest dependency graph for a project by reading open GitHub issues, analyzing the codebase, inferring dependencies, and seeding a PGlite database. The result is a queryable graph that answers: *what work exists, what depends on what, and what can run now?*
+Build a manifest dependency graph for a project by reading open GitHub issues, analyzing the codebase, inferring dependencies, and seeding a SQLite database. The result is a queryable graph that answers: *what work exists, what depends on what, and what can run now?*
 
 Reference: `docs/MANIFEST_SYSTEM_DESIGN_V2.md` Sections 10.1-10.4
 
@@ -59,7 +59,7 @@ Read the project's `CLAUDE.md` and extract the `context-path` setting:
 grep -E '^\s*-\s*\*\*context-path\*\*' CLAUDE.md
 ```
 
-The manifest database lives at `{context-path}/manifest/pgdata/`.
+The manifest database lives at `{context-path}/manifest/manifest.db`.
 
 ### 0.2 Verify Manifest CLI
 
@@ -85,7 +85,7 @@ Run: cd manifest && npm install
 ### 0.3 Ensure Database Directory
 
 ```bash
-mkdir -p {context-path}/manifest/pgdata
+mkdir -p {context-path}/manifest
 ```
 
 ### 0.4 Test CLI
@@ -100,7 +100,7 @@ If this fails, report the error and stop. If it succeeds (even with 0 items), th
 ```
 Manifest infrastructure verified:
   CLI: manifest/manifest-cli.ts
-  Database: {context-path}/manifest/pgdata/
+  Database: {context-path}/manifest/manifest.db
   Status: {item count} existing items
 ```
 
@@ -324,7 +324,7 @@ Present the mapping for confirmation if any assignments are uncertain.
 
 ---
 
-## Phase 4: Seed Work Items into PGlite
+## Phase 4: Seed Work Items into SQLite
 
 **Goal:** Generate SQL and apply it via the manifest CLI.
 
@@ -845,10 +845,10 @@ Because all seed SQL uses `INSERT ... ON CONFLICT (id) DO NOTHING`, re-running b
 - Existing edges are not duplicated
 - File predictions use UPDATE so they will refresh
 
-To force a full rebuild, delete the PGlite data directory and re-run:
+To force a full rebuild, delete the SQLite database file and re-run:
 
 ```bash
-rm -rf {context-path}/manifest/pgdata
+rm -f {context-path}/manifest/manifest.db
 manifest-bootstrap
 ```
 

--- a/skills/manifest-check/SKILL.md
+++ b/skills/manifest-check/SKILL.md
@@ -61,7 +61,7 @@ Read the project's `CLAUDE.md` and extract the `context-path` setting:
 grep -E '^\s*-\s*\*\*context-path\*\*' CLAUDE.md
 ```
 
-The manifest database lives at `{context-path}/manifest/pgdata/`.
+The manifest database lives at `{context-path}/manifest/manifest.db`.
 
 ### 0.2 Verify Manifest CLI
 
@@ -75,7 +75,7 @@ If `node_modules` is absent, stop and ask user to run `cd manifest && npm instal
 ### 0.3 Verify Database Exists
 
 ```bash
-ls {context-path}/manifest/pgdata/
+ls {context-path}/manifest/manifest.db
 ```
 
 If no database exists, this skill cannot run -- the manifest must be bootstrapped first:
@@ -399,7 +399,7 @@ Write-back: {applied/prepared/skipped}
 
 ### No Manifest Database
 ```
-No manifest database found at {context-path}/manifest/pgdata/.
+No manifest database found at {context-path}/manifest/manifest.db.
 Run manifest-bootstrap first to initialize.
 ```
 

--- a/skills/manifest-dispatch/SKILL.md
+++ b/skills/manifest-dispatch/SKILL.md
@@ -59,7 +59,7 @@ Warning: manifest dependencies not installed.
 Run: cd manifest && npm install
 ```
 
-### 0.3 Verify PGlite database
+### 0.3 Verify SQLite database
 
 ```bash
 node --import tsx manifest/manifest-cli.ts status

--- a/skills/manifest-plan/SKILL.md
+++ b/skills/manifest-plan/SKILL.md
@@ -254,7 +254,7 @@ This is the simplest case -- every item gets its own parallel group.
 - Before `manifest-dispatch` begins
 
 **Reads from:**
-- Manifest PGlite database (via CLI)
+- Manifest SQLite database (via CLI)
 - Shared files in the codebase (for conflict classification)
 - Project CLAUDE.md (for resource constraints)
 

--- a/skills/manifest-sync/SKILL.md
+++ b/skills/manifest-sync/SKILL.md
@@ -59,7 +59,7 @@ Read the project's `CLAUDE.md` and extract the `context-path` setting:
 grep -E '^\s*-\s*\*\*context-path\*\*' CLAUDE.md
 ```
 
-The manifest database lives at `{context-path}/manifest/pgdata/`.
+The manifest database lives at `{context-path}/manifest/manifest.db`.
 
 ### 0.2 Verify Manifest CLI
 
@@ -70,12 +70,12 @@ Confirm the manifest CLI and database exist:
 ls manifest/manifest-cli.ts
 
 # Check database exists
-ls {context-path}/manifest/pgdata/
+ls {context-path}/manifest/manifest.db
 ```
 
 If database does not exist:
 ```
-No manifest database found at {context-path}/manifest/pgdata/.
+No manifest database found at {context-path}/manifest/manifest.db.
 Run manifest-bootstrap first to initialize the manifest.
 ```
 **Stop.**


### PR DESCRIPTION
## Summary
Replace @electric-sql/pglite with better-sqlite3 for manifest storage after PGlite became irrecoverably corrupted during first production bootstrap (systema-relica ecosystem, 139 items, 136 edges).

## Issue Resolution
Closes #52

SQLite provides single-file storage, sub-ms startup, and 20 years of battle-tested reliability — addressing all failure modes that caused the PGlite corruption (stale lock files, WAL segments, opaque WASM errors).

## Key Changes
- **Dependencies**: `@electric-sql/pglite` -> `better-sqlite3` + `@types/better-sqlite3`
- **Schema**: `TEXT[]` -> JSON arrays, `JSONB` -> `TEXT`, `TIMESTAMPTZ` -> `strftime()`, removed GIN indexes
- **SQL queries**: Array overlap via `json_each()` joins, `json_extract()`/`json_set()` functions, `?` params
- **init.ts**: Synchronous API, context-path parsing from CLAUDE.md, WAL mode, foreign key enforcement
- **manifest-cli.ts**: Synchronous API, `--data-dir` flag, `parseJsonArray` helper for JSON column results
- **plan.ts / seed.ts**: Synchronous API, prepared statements for batch inserts
- **All 6 test files**: In-memory SQLite (`:memory:`), synchronous assertions
- **Skill docs**: Updated all 5 manifest skills (`pgdata/` -> `manifest.db`)

## Testing
- All 6 test suites pass (schema, queries, plan, check, CLI, seed)
- TypeScript compiles clean (`tsc --noEmit`)
- Corrupted pgdata directory deleted; clean rebuild via seed.ts confirmed

## Checklist
- [x] Code follows project conventions
- [x] Changes are atomic and reviewable
- [x] Skill documentation updated
- [x] All tests pass